### PR TITLE
feat: add assetHistoricEarnings

### DIFF
--- a/src/services/subgraph/apollo/queries.ts
+++ b/src/services/subgraph/apollo/queries.ts
@@ -57,3 +57,19 @@ export const ACCOUNT_EARNINGS = gql`
     }
   }
 `;
+
+export const ASSET_HISTORIC_EARNINGS = gql`
+  query AssetHistoricEarnings($id: ID!, $sinceDate: Int!) {
+    vault(id: $id) {
+      id
+      token {
+        id
+        decimals
+      }
+      vaultDayData(where: { date_gt: $sinceDate }) {
+        dayReturnsGenerated
+        date
+      }
+    }
+  }
+`;


### PR DESCRIPTION
Add the ability to get daily data for assets aka vaults. And some minor tidying up

After this I'll add the ability to get historical earnings for accounts, then after that I'll manually add the queries/types so we can remove apollo to save space