### PR TITLE
fix(subgraph): prevent caching subgraph requests

### DIFF
--- a/src/services/subgraph/index.ts
+++ b/src/services/subgraph/index.ts
@@ -11,6 +11,16 @@ export class SubgraphService extends Service {
     link: new HttpLink({
       uri: YearnSubgraphEndpoint
     }),
-    cache: new InMemoryCache()
+    cache: new InMemoryCache(),
+    defaultOptions: {
+      watchQuery: {
+        fetchPolicy: 'no-cache',
+        errorPolicy: 'ignore',
+      },
+      query: {
+        fetchPolicy: 'no-cache',
+        errorPolicy: 'all',
+      },
+    }
   });
 }


### PR DESCRIPTION
Currently, the subgraph is caching everything, which I would consider a broken state.
This PR prevents any caching until a proper caching policy is implemented.

Edit: Unfortunately, just had my phone with me to write this PR, and seems like Github included my comment as the commit description. I can remove it later if needed. 