### PR TITLE
fix: refined logic for account historic earnings calculation [WEB-337]

### DIFF
--- a/src/services/subgraph/apollo/queries.ts
+++ b/src/services/subgraph/apollo/queries.ts
@@ -87,6 +87,7 @@ export const ACCOUNT_HISTORIC_EARNINGS = gql`
           vaultDayData(where: { date_gt: $sinceDate }, orderBy: date, orderDirection: asc, first: 1000) {
             pricePerShare
             date
+            tokenPriceUSDC
           }
         }
         updates(orderBy: timestamp, orderDirection: asc, first: 1000) {


### PR DESCRIPTION
tokenPriceUSDC has been added to `VaultDayData` in the subgraph so we can remove the sdk usage of the oracle for this

also https://github.com/yearn/yearn-vaults-v2-subgraph/issues/60 has been fixed so removed the checks related to it