### PR TITLE
chore: remove isProtocolFee from apollo codegen

### DIFF
--- a/src/services/subgraph/apollo/queries.ts
+++ b/src/services/subgraph/apollo/queries.ts
@@ -108,7 +108,7 @@ export const ACCOUNT_HISTORIC_EARNINGS = gql`
 
 export const PROTOCOL_FEES = gql`
   query ProtocolFees($sinceDate: BigInt!) {
-    transfers(where: { timestamp_gt: $sinceDate, isProtocolFee: true }, first: 1000) {
+    transfers(where: { timestamp_gt: $sinceDate }, first: 1000) {
       tokenAmountUsdc
     }
   }


### PR DESCRIPTION
Codegen routine was erroring:

```
.../services/subgraph/apollo/queries.ts: Field "isProtocolFee" is not defined by type "Transfer_filter".
```
