### PR TITLE
fix: corrected typo of allowances helper function

### DIFF
--- a/src/services/helper.ts
+++ b/src/services/helper.ts
@@ -87,6 +87,6 @@ export class HelperService<T extends ChainId> extends ContractService<T> {
     spenders: Address[],
     overrides: CallOverrides = {}
   ): Promise<TokenAllowance[]> {
-    return await this.contract.read.allowance(address, tokens, spenders, overrides).then(structArray);
+    return await this.contract.read.allowances(address, tokens, spenders, overrides).then(structArray);
   }
 }


### PR DESCRIPTION
https://etherscan.io/address/0x4218e20db87023049fc582aaa4bd47a3611a20ab#readContract

`allowances` not `allowance`