### PR TITLE
fix: correct accountHistoricEarnings query variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .DS_Store
 yarn-error.log
 
+.history/
 .vscode/
 out/
 docs/

--- a/src/services/subgraph/queries.ts
+++ b/src/services/subgraph/queries.ts
@@ -85,8 +85,8 @@ export const ASSET_HISTORIC_EARNINGS = (blocks: number[]) => {
   return result;
 };
 
-export const ACCOUNT_HISTORIC_EARNINGS = `query AccountHistoricEarnings($id: ID!, $fromDate: String!, $sinceDate: BigInt!, $toDate: BigInt!) {
-    account(id: $id) {
+export const ACCOUNT_HISTORIC_EARNINGS = `query AccountHistoricEarnings($id: ID!, $shareToken: String!, $fromDate: String!, $toDate: BigInt!) {
+  account(id: $id) {
       vaultPositions(where: { shareToken: $shareToken }) {
         balanceShares
         token {


### PR DESCRIPTION
…ent into query did not match query definition.

See file src/interfaces/earnings.ts:271 (accountHistoricEarnings) for implementation.

Query variables passed into the query did not match the query variables defined in queries.ts