### PR TITLE
[WEB-1141-184] Fix: resolving missing fetch import

### DIFF
--- a/src/services/assets.ts
+++ b/src/services/assets.ts
@@ -1,3 +1,5 @@
+import fetch from "cross-fetch";
+
 import { ChainId } from "../chain";
 import { Service } from "../common";
 import { Context } from "../context";


### PR DESCRIPTION
When writing tests for simulations, `ReferenceError: fetch is not defined` is thrown.  Just missing the import.