### PR TITLE
fix: use correct scopes for validateCallData with allowlist service

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -56,6 +56,12 @@ export interface ContextValue {
   addresses?: PartialDeep<AddressesOverride>;
   simulation?: SimulationConfiguration;
   cache?: CacheConfiguration;
+  /**
+   * This is a required parameter
+   * If true it will disable the use of allowlist to validate tx's.
+   * If false it will validate each tx againts the allowlist contracts and it will
+   * override the JsonRpcSigner sendTransaction method to always try to validate, use with caution
+  */
   disableAllowlist: boolean;
 }
 

--- a/src/context.ts
+++ b/src/context.ts
@@ -56,6 +56,7 @@ export interface ContextValue {
   addresses?: PartialDeep<AddressesOverride>;
   simulation?: SimulationConfiguration;
   cache?: CacheConfiguration;
+  disableAllowlist: boolean;
 }
 
 const DefaultContext = {
@@ -89,6 +90,7 @@ export class Context implements Required<ContextValue> {
     this.ctx = Object.assign({}, DefaultContext, ctx);
     this.events = new EventEmitter().setMaxListeners(100);
     this.setProvider(ctx.provider);
+    this.ctx.disableAllowlist = ctx.disableAllowlist;
   }
 
   /**
@@ -132,5 +134,10 @@ export class Context implements Required<ContextValue> {
   get cache(): CacheConfiguration {
     if (this.ctx.cache) return this.ctx.cache;
     throw new SdkError("cache must be defined in Context for this feature to work.");
+  }
+
+  get disableAllowlist(): boolean {
+    if (this.ctx.disableAllowlist) return this.ctx.disableAllowlist;
+    throw new SdkError("disableAllowlist must be defined in Context for this feature to work.");
   }
 }

--- a/src/context.ts
+++ b/src/context.ts
@@ -61,7 +61,7 @@ export interface ContextValue {
    * If true it will disable the use of allowlist to validate tx's.
    * If false it will validate each tx againts the allowlist contracts and it will
    * override the JsonRpcSigner sendTransaction method to always try to validate, use with caution
-  */
+   */
   disableAllowlist: boolean;
 }
 

--- a/src/services/allowlist.ts
+++ b/src/services/allowlist.ts
@@ -27,13 +27,14 @@ export class AllowListService<T extends ChainId> extends ContractService<T> {
    * @param chainId
    * @returns address
    */
-  static addressByChain(chainId: ChainId): string | null {
+  static addressByChain(chainId?: ChainId): string | null {
     switch (chainId) {
       case 250:
         return "0xD2322468e5Aa331381200754f6daAD3dF923539e";
       case 1:
       case 1337:
       case 42161:
+      default:
         return null;
     }
   }

--- a/src/services/allowlist.ts
+++ b/src/services/allowlist.ts
@@ -27,7 +27,7 @@ export class AllowListService<T extends ChainId> extends ContractService<T> {
    * @param chainId
    * @returns address
    */
-  static addressByChain(chainId?: ChainId): string | null {
+  static addressByChain(chainId: ChainId): string | null {
     switch (chainId) {
       case 250:
         return "0xD2322468e5Aa331381200754f6daAD3dF923539e";

--- a/src/yearn.ts
+++ b/src/yearn.ts
@@ -86,7 +86,7 @@ export class Yearn<T extends ChainId> {
   constructor(chainId: T, context: ContextValue, assetServiceState?: AssetServiceState) {
     this.context = new Context(context);
 
-    const allowlistAddress = AllowListService.addressByChain(chainId);
+    const allowlistAddress = !this.context.disableAllowlist && AllowListService.addressByChain(chainId);
 
     this.services = {
       lens: new LensService(chainId, this.context),
@@ -116,7 +116,7 @@ export class Yearn<T extends ChainId> {
   }
 
   setChainId(chainId: ChainId) {
-    const allowlistAddress = AllowListService.addressByChain(chainId);
+    const allowlistAddress = !this.context.disableAllowlist && AllowListService.addressByChain(chainId);
 
     this.services = {
       lens: new LensService(chainId, this.context),

--- a/src/yearn.ts
+++ b/src/yearn.ts
@@ -110,7 +110,7 @@ export class Yearn<T extends ChainId> {
     this.simulation = new SimulationInterface(this, chainId, this.context);
     this.strategies = new StrategyInterface(this, chainId, this.context);
 
-    // this.configureSignerWithAllowlist(); // NOTE: temporarily disable allowlist validation
+    this.configureSignerWithAllowlist();
 
     this.ready = Promise.all([this.services.asset.ready]);
   }
@@ -140,7 +140,7 @@ export class Yearn<T extends ChainId> {
     this.simulation = new SimulationInterface(this, chainId, this.context);
     this.strategies = new StrategyInterface(this, chainId, this.context);
 
-    // this.configureSignerWithAllowlist(); // NOTE: temporarily disable allowlist validation
+    this.configureSignerWithAllowlist();
 
     this.ready = Promise.all([this.services.asset.ready]);
   }

--- a/src/yearn.ts
+++ b/src/yearn.ts
@@ -24,7 +24,7 @@ import { ZapperService } from "./services/zapper";
 import { SdkError } from "./types/common";
 import { AssetServiceState } from "./types/custom/assets";
 
-const orig = JsonRpcSigner.prototype.sendTransaction;
+const originalJsonRpcSignerSendTransaction = JsonRpcSigner.prototype.sendTransaction;
 
 /**
  * [[Yearn]] is a wrapper for all the services and interfaces of the SDK.
@@ -163,10 +163,10 @@ export class Yearn<T extends ChainId> {
         if (!valid) {
           throw new SdkError("transaction is not valid");
         }
-        return orig.apply(this, [transaction]);
+        return originalJsonRpcSignerSendTransaction.apply(this, [transaction]);
       };
     } else {
-      JsonRpcSigner.prototype.sendTransaction = orig;
+      JsonRpcSigner.prototype.sendTransaction = originalJsonRpcSignerSendTransaction;
     }
   }
 }

--- a/src/yearn.ts
+++ b/src/yearn.ts
@@ -155,10 +155,10 @@ export class Yearn<T extends ChainId> {
 
       const [to, data] = await Promise.all([transaction.to, transaction.data]);
       return await this.services.allowList.validateCalldata(to, data).then(res => res.success);
-    }
+    };
 
     if (shouldValidate) {
-      JsonRpcSigner.prototype.sendTransaction = async function (transaction: Deferrable<TransactionRequest>) {
+      JsonRpcSigner.prototype.sendTransaction = async function(transaction: Deferrable<TransactionRequest>) {
         const valid = await validateTx(transaction);
         if (!valid) {
           throw new SdkError("transaction is not valid");
@@ -166,7 +166,7 @@ export class Yearn<T extends ChainId> {
         return orig.apply(this, [transaction]);
       };
     } else {
-      JsonRpcSigner.prototype.sendTransaction = orig
+      JsonRpcSigner.prototype.sendTransaction = orig;
     }
   }
 }


### PR DESCRIPTION
Explanation of what was hapenning:
Originally we had this 
```
configureSignerWithAllowlist() {
    const validateTx = async (transaction: Deferrable<TransactionRequest>) => {
      if (!this.services.allowList) {
        return true;
      }

      const [to, data] = await Promise.all([transaction.to, transaction.data]);
      return await this.services.allowList.validateCalldata(to, data).then(res => res.success);
    };

    const orig = JsonRpcSigner.prototype.sendTransaction;
    JsonRpcSigner.prototype.sendTransaction = async function(transaction: Deferrable<TransactionRequest>) {
      const valid = await validateTx(transaction);
      if (!valid) {
        throw new SdkError("transaction is not valid");
      }
      return orig.apply(this, [transaction]);
    };
  }
 ```
 
 `configureSignerWithAllowlist` was being called each time a new instance of Yearn was being created. The problem here came from this line specifically `const orig = JsonRpcSigner.prototype.sendTransaction;`. When the first Yearn instance was created, the `JsonRpcSigner` prototype was overriden and it worked correctly for this instance, when a new instance was created the prototype was overriden again and this is where the problems started happening, lets go with a quick example to understand what is happening under the hood:
- Lets say that `JsonRpcSigner.protype` is a function that does `a`. 
- The first time that the `Yearn` instance is created, we grab the `JsonRpcSigner` prototype at the time of creation, which only does `a`, (the `orig` variable) and this prototype is overriden to do `b + a`, where `b` in our case is to validate the tx, whenever `b` is called it is read with the context where `b` was created (lets say that we do not have an `allowlistservice` here).
- The second time the a `Yearn` instance is created, we go through this process again, but now the `JsonRpcSigner` prototype is no longer just `a`, now its `b + a`, because we overrode it on the first instance creation. And we override it again, so now the `JsonRpcSigner` prototype does `c + b + a`. And lets say that now `allowlistservice` DOES exist.
- Once we make a transaction from the second instance, first is going to execute `c` (with the context where c was created), this is going to execute succesfully, BUT when it gets to execute `b` `this.services.allowList` is false on that context, but because of the way javascript scopes/contexts work, it will go up the chain of scopes to find the nearest `services.allowlist` which is true on the context of `c` so it tries to execute `validateCallData` and it fails.


What are we doing to fix this:
- Define the original prototype at the top of the file so it is inmutable regarding when the instances get created, this makes it so that in our example, when the second instance is created, the prototype just does `c + a` instead of `c + b + a`.
- Do not modify the prototype of the function if it is not required (either allowlistservice does not exist, or the user has opted-out of using the allowlist)

Caveats:
- We can only run one instance of the yearn sdk at the time, since if this is not true, the prototype of the JsonRpcSigner.sendTransaction is going to get overriden by the last created instance and it might not work as expected
 