### PR TITLE
test: Add specs for the `EarningsInterface`

### DIFF
--- a/src/interfaces/earnings.spec.ts
+++ b/src/interfaces/earnings.spec.ts
@@ -1,0 +1,57 @@
+import { ChainId, EarningsInterface } from "..";
+import { Context } from "../context";
+import { Yearn } from "../yearn";
+
+const subgraphFetchQueryMock = jest.fn();
+
+jest.mock("../yearn", () => ({
+  Yearn: jest.fn().mockImplementation(() => ({
+    services: {
+      subgraph: {
+        fetchQuery: subgraphFetchQueryMock
+      },
+      vision: {},
+      lens: {},
+      oracle: {}
+    }
+  }))
+}));
+
+describe("EarningsInterface", () => {
+  let earningsInterface: EarningsInterface<1>;
+
+  let mockedYearn: Yearn<ChainId>;
+
+  beforeEach(() => {
+    mockedYearn = new (Yearn as jest.Mock<Yearn<ChainId>>)();
+    earningsInterface = new EarningsInterface(mockedYearn, 1, new Context({}));
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("protocolEarnings", () => {
+    describe("when there is no response", () => {
+      beforeEach(() => {
+        subgraphFetchQueryMock.mockResolvedValue(undefined);
+      });
+
+      it("should return a string representing the value of BigNumber(0)", async () => {
+        const actualProtocolEarnings = await earningsInterface.protocolEarnings();
+
+        expect(actualProtocolEarnings).toEqual("0");
+      });
+    });
+  });
+
+  describe("assetEarnings", () => {});
+
+  describe("accountAssetsData", () => {});
+
+  describe("assetsHistoricEarnings", () => {});
+
+  describe("assetHistoricEarnings", () => {});
+
+  describe("accountHistoricEarnings", () => {});
+});

--- a/src/interfaces/earnings.spec.ts
+++ b/src/interfaces/earnings.spec.ts
@@ -1,7 +1,7 @@
 import { getAddress } from "@ethersproject/address";
 import BigNumber from "bignumber.js";
 
-import { AssetHistoricEarnings, ChainId, EarningsInterface, SdkError, Usdc, VaultStatic } from "..";
+import { Address, AssetHistoricEarnings, ChainId, EarningsInterface, SdkError, Usdc, VaultStatic } from "..";
 import { Context } from "../context";
 import { createMockAssetHistoricEarnings, createMockAssetStaticVaultV2 } from "../test-utils/factories";
 import { Yearn } from "../yearn";
@@ -120,6 +120,8 @@ describe("EarningsInterface", () => {
     });
 
     describe("when there is data", () => {
+      const assetAddress: Address = "0x001";
+
       beforeEach(() => {
         getAddressMock.mockReturnValue("0x001");
         oracleGetPriceUsdcMock.mockResolvedValueOnce("3.5");
@@ -139,7 +141,7 @@ describe("EarningsInterface", () => {
       });
 
       it("should return the asset earnings", async () => {
-        const actualAssetEarnings = await earningsInterface.assetEarnings("0x001");
+        const actualAssetEarnings = await earningsInterface.assetEarnings(assetAddress);
 
         expect(actualAssetEarnings).toEqual({
           amount: "2000000000000000000",
@@ -151,7 +153,7 @@ describe("EarningsInterface", () => {
         expect(oracleGetPriceUsdcMock).toHaveBeenCalledWith("vaultTokenId");
 
         expect(getAddress).toHaveBeenCalledTimes(2);
-        expect(getAddress).toHaveBeenNthCalledWith(1, "0x001");
+        expect(getAddress).toHaveBeenNthCalledWith(1, assetAddress);
         expect(getAddress).toHaveBeenNthCalledWith(2, "vaultTokenId");
       });
     });

--- a/src/interfaces/earnings.ts
+++ b/src/interfaces/earnings.ts
@@ -56,11 +56,11 @@ export class EarningsInterface<C extends ChainId> extends ServiceInterface<C> {
       vault: assetAddress
     });
 
-    const vault = response.data.vault;
-
-    if (!vault) {
+    if (!response?.data || !response.data?.vault) {
       throw new SdkError(`No asset with address ${assetAddress}`);
     }
+
+    const { vault } = response.data;
 
     const returnsGenerated = new BigNumber(vault.latestUpdate?.returnsGenerated || 0);
     const earningsUsdc = await this.tokensValueInUsdc(returnsGenerated, vault.token.id, vault.token.decimals);

--- a/src/interfaces/earnings.ts
+++ b/src/interfaces/earnings.ts
@@ -31,9 +31,14 @@ const BigZero = new BigNumber(0);
 
 export class EarningsInterface<C extends ChainId> extends ServiceInterface<C> {
   async protocolEarnings(): Promise<String> {
-    const response = (await this.yearn.services.subgraph.fetchQuery(PROTOCOL_EARNINGS)) as ProtocolEarningsResponse;
+    const response = await this.yearn.services.subgraph.fetchQuery<ProtocolEarningsResponse>(PROTOCOL_EARNINGS);
 
     let result = BigZero;
+
+    if (!response?.data || !response.data?.vaults) {
+      return result.toFixed(0);
+    }
+
     for (const vault of response.data.vaults) {
       if (!vault.latestUpdate) {
         continue;
@@ -47,9 +52,9 @@ export class EarningsInterface<C extends ChainId> extends ServiceInterface<C> {
   }
 
   async assetEarnings(assetAddress: Address): Promise<AssetEarnings> {
-    const response = (await this.yearn.services.subgraph.fetchQuery(VAULT_EARNINGS, {
+    const response = await this.yearn.services.subgraph.fetchQuery<VaultEarningsResponse>(VAULT_EARNINGS, {
       vault: assetAddress
-    })) as VaultEarningsResponse;
+    });
 
     const vault = response.data.vault;
 
@@ -68,10 +73,10 @@ export class EarningsInterface<C extends ChainId> extends ServiceInterface<C> {
   }
 
   async accountAssetsData(accountAddress: Address): Promise<EarningsUserData> {
-    const response = (await this.yearn.services.subgraph.fetchQuery(
+    const response = await this.yearn.services.subgraph.fetchQuery<AccountEarningsResponse>(
       ACCOUNT_EARNINGS,
       buildAccountEarningsVariables(accountAddress)
-    )) as AccountEarningsResponse;
+    );
 
     const account = response.data.account;
 
@@ -216,9 +221,9 @@ export class EarningsInterface<C extends ChainId> extends ServiceInterface<C> {
       .reverse()
       .map(day => blockNumber - day * this.blocksPerDay());
 
-    const response = (await this.yearn.services.subgraph.fetchQuery(ASSET_HISTORIC_EARNINGS(blocks), {
+    const response = await this.yearn.services.subgraph.fetchQuery<any>(ASSET_HISTORIC_EARNINGS(blocks), {
       id: vault
-    })) as any;
+    });
 
     const data = response.data;
 
@@ -273,16 +278,19 @@ export class EarningsInterface<C extends ChainId> extends ServiceInterface<C> {
       throw new SdkError("fromDaysAgo must be greater than toDaysAgo");
     }
 
-    const response = (await this.yearn.services.subgraph.fetchQuery(ACCOUNT_HISTORIC_EARNINGS, {
-      id: accountAddress,
-      shareToken: shareTokenAddress,
-      fromDate: this.getDate(fromDaysAgo)
-        .getTime()
-        .toString(),
-      toDate: this.getDate(toDaysAgo || 0)
-        .getTime()
-        .toString()
-    })) as AccountHistoricEarningsResponse;
+    const response = await this.yearn.services.subgraph.fetchQuery<AccountHistoricEarningsResponse>(
+      ACCOUNT_HISTORIC_EARNINGS,
+      {
+        id: accountAddress,
+        shareToken: shareTokenAddress,
+        fromDate: this.getDate(fromDaysAgo)
+          .getTime()
+          .toString(),
+        toDate: this.getDate(toDaysAgo || 0)
+          .getTime()
+          .toString()
+      }
+    );
 
     const vaultPositions = response.data.account?.vaultPositions;
 

--- a/src/interfaces/fees.ts
+++ b/src/interfaces/fees.ts
@@ -8,9 +8,9 @@ import { Usdc } from "../types";
 
 export class FeesInterface<C extends ChainId> extends ServiceInterface<C> {
   async protocolFees(since: Date): Promise<Usdc> {
-    const response = (await this.yearn.services.subgraph.fetchQuery(PROTOCOL_FEES, {
+    const response = await this.yearn.services.subgraph.fetchQuery<FeesResponse>(PROTOCOL_FEES, {
       sinceDate: since.getTime().toString()
-    })) as FeesResponse;
+    });
 
     const transfers = response.data.transfers;
 

--- a/src/services/subgraph/index.ts
+++ b/src/services/subgraph/index.ts
@@ -28,7 +28,7 @@ export class SubgraphService extends Service {
     this.yearnSubgraphEndpoint = `https://api.thegraph.com/subgraphs/name/${subgraphName}`;
   }
 
-  async fetchQuery(query: string, variables: { [key: string]: any } = {}): Promise<unknown> {
+  async fetchQuery<T>(query: string, variables: { [key: string]: any } = {}): Promise<T> {
     // the subgraph only works with lowercased addresses
     Object.keys(variables).forEach(key => {
       const variable = variables[key];

--- a/src/test-utils/factories/assetHistoricEarnings.factory.ts
+++ b/src/test-utils/factories/assetHistoricEarnings.factory.ts
@@ -1,0 +1,12 @@
+import { AssetHistoricEarnings } from "../..";
+
+export const DEFAULT_ASSET_HISTORIC_EARNINGS: AssetHistoricEarnings = {
+  assetAddress: "0x001",
+  decimals: 18,
+  dayData: [{ earnings: { amount: "1", amountUsdc: "1" }, date: "15-02-2022" }]
+};
+
+export const createMockAssetHistoricEarnings = (overwrites: Partial<AssetHistoricEarnings> = {}) => ({
+  ...DEFAULT_ASSET_HISTORIC_EARNINGS,
+  ...overwrites
+});

--- a/src/test-utils/factories/index.ts
+++ b/src/test-utils/factories/index.ts
@@ -1,3 +1,4 @@
 export * from "./asset.factory";
+export * from "./assetHistoricEarnings.factory";
 export * from "./balance.factory";
 export * from "./token.factory";


### PR DESCRIPTION
Partly addresses https://github.com/yearn/yearn-sdk/issues/211

Add the following tests for the `EarningsInterface`

* `protocolEarnings`
* `assetEarnings`
* `assetsHistoricEarnings`

The remaining tests will be done in a separate PR for quicker review time following a discussion on Telegram with @xgambitox 

* `accountAssetsData`
* `assetHistoricEarnings`
* `accountHistoricEarnings`