### PR TITLE
feat: allow signed approvals on withdraw

### DIFF
--- a/src/interfaces/vault.spec.ts
+++ b/src/interfaces/vault.spec.ts
@@ -827,7 +827,17 @@ describe("VaultInterface", () => {
 
           expect(actualWithdraw).toBe("executeZapperTransactionResponse");
           expect(zapperZapOutMock).toHaveBeenCalledTimes(1);
-          expect(zapperZapOutMock).toHaveBeenCalledWith("0xAccount", "0xToken", "1", "0xVault", "0", 1, false);
+          expect(zapperZapOutMock).toHaveBeenCalledWith(
+            "0xAccount",
+            "0xToken",
+            "1",
+            "0xVault",
+            "0",
+            1,
+            false,
+            undefined,
+            undefined
+          );
           expect(executeZapperTransactionMock).toHaveBeenCalledTimes(1);
           expect(executeZapperTransactionMock).toHaveBeenCalledWith(
             {

--- a/src/interfaces/vault.ts
+++ b/src/interfaces/vault.ts
@@ -375,7 +375,9 @@ export class VaultInterface<T extends ChainId> extends ServiceInterface<T> {
         vault,
         "0",
         options.slippage,
-        false
+        false,
+        undefined,
+        options.signature
       );
 
       const transactionRequest: TransactionRequest = {

--- a/src/services/zapper.ts
+++ b/src/services/zapper.ts
@@ -276,6 +276,7 @@ export class ZapperService extends Service {
    * @param slippagePercentage - slippage as a decimal
    * @param skipGasEstimate - provide the gasLimit in the response. Should be set to true when simulating a zap without approval
    * @param zapProtocol the protocol to use with zapper e.g. Yearn, Pickle
+   * @param signature - the account valid secp256k1 signature of Permit encoded from r, s, v. (https://eips.ethereum.org/EIPS/eip-2612)
    */
   async zapOut(
     from: Address,
@@ -285,7 +286,8 @@ export class ZapperService extends Service {
     gasPrice: Integer,
     slippagePercentage: number,
     skipGasEstimate: boolean,
-    zapProtocol: ZapProtocol = ZapProtocol.YEARN
+    zapProtocol: ZapProtocol = ZapProtocol.YEARN,
+    signature?: string
   ): Promise<ZapOutput> {
     let toToken = token;
     if (EthAddress === token) {
@@ -304,7 +306,8 @@ export class ZapperService extends Service {
       slippagePercentage: slippagePercentage.toString(),
       api_key: this.ctx.zapper,
       shouldSellEntireBalance: "true",
-      skipGasEstimate: skipGasEstimate ? "true" : "false"
+      skipGasEstimate: skipGasEstimate ? "true" : "false",
+      ...(signature && { signature })
     });
     const response: ZapOutput = await fetch(`${url}?${params}`)
       .then(handleHttpError)

--- a/src/types/custom/vault.ts
+++ b/src/types/custom/vault.ts
@@ -43,7 +43,9 @@ export interface Apy {
 export type ApyMap<T extends Address> = TypedMap<T, Apy | undefined>;
 
 export interface DepositOptions extends ZapOptions {}
-export interface WithdrawOptions extends ZapOptions {}
+export interface WithdrawOptions extends ZapOptions {
+  signature?: string;
+}
 
 export interface VaultsUserSummary {
   holdings: Usdc;


### PR DESCRIPTION
- Add functionality to allow signed approvals for zap out withdrawals, based on [eip-2612](https://eips.ethereum.org/EIPS/eip-2612) and integration on zapper's [ZapOutWithPermit](https://etherscan.io/address/0xd6b88257e91e4E4D4E990B3A858c849EF2DFdE8c#code#F8#L117) method