### PR TITLE
add `Deprecated` comment

### DIFF
--- a/src/interfaces/earnings.ts
+++ b/src/interfaces/earnings.ts
@@ -32,6 +32,7 @@ const BigZero = new BigNumber(0);
 export class EarningsInterface<C extends ChainId> extends ServiceInterface<C> {
 /**
  * @deprecated
+ * Not able to be accurately calculated by the subgraph, this functionality will be removed in a future version
  */
   async protocolEarnings(): Promise<String> {
     const response = await this.yearn.services.subgraph.fetchQuery<ProtocolEarningsResponse>(PROTOCOL_EARNINGS);

--- a/src/interfaces/earnings.ts
+++ b/src/interfaces/earnings.ts
@@ -30,6 +30,9 @@ import {
 const BigZero = new BigNumber(0);
 
 export class EarningsInterface<C extends ChainId> extends ServiceInterface<C> {
+/**
+ * @deprecated
+ */
   async protocolEarnings(): Promise<String> {
     const response = await this.yearn.services.subgraph.fetchQuery<ProtocolEarningsResponse>(PROTOCOL_EARNINGS);
 

--- a/src/interfaces/earnings.ts
+++ b/src/interfaces/earnings.ts
@@ -30,10 +30,10 @@ import {
 const BigZero = new BigNumber(0);
 
 export class EarningsInterface<C extends ChainId> extends ServiceInterface<C> {
-/**
- * @deprecated
- * Not able to be accurately calculated by the subgraph, this functionality will be removed in a future version
- */
+  /**
+   * @deprecated
+   * Not able to be accurately calculated by the subgraph, this functionality will be removed in a future version
+   */
   async protocolEarnings(): Promise<String> {
     const response = await this.yearn.services.subgraph.fetchQuery<ProtocolEarningsResponse>(PROTOCOL_EARNINGS);
 


### PR DESCRIPTION
add `deprecated` comment to the `protocolEarnings` function according to the `JSDoc` documentation.