### PR TITLE
refactor: Handle errors more gracefully

### DIFF
--- a/src/interfaces/token.spec.ts
+++ b/src/interfaces/token.spec.ts
@@ -163,14 +163,14 @@ describe("TokenInterface", () => {
           expect(ironBankBalancesMock).not.toHaveBeenCalled();
         });
 
-        it("should return an empty array when zapper fails", async () => {
+        it("should return only tokens from the vaults when zapper fails", async () => {
           zapperBalancesMock.mockImplementation(() => {
             throw new Error("zapper balances failed!");
           });
 
           const actualBalances = await tokenInterface.balances("0x000");
 
-          expect(actualBalances).toEqual([]);
+          expect(actualBalances).toEqual([vaultTokenWithBalance]);
           expect(zapperBalancesMock).toHaveBeenCalledTimes(1);
           expect(zapperBalancesMock).toHaveBeenCalledWith("0x000");
           expect(ironBankBalancesMock).not.toHaveBeenCalled();

--- a/src/interfaces/token.ts
+++ b/src/interfaces/token.ts
@@ -7,7 +7,7 @@ import { ChainId } from "../chain";
 import { ServiceInterface } from "../common";
 import { EthAddress } from "../helpers";
 import { PickleJars } from "../services/partners/pickle";
-import { Address, Integer, SdkError, TokenMetadata, TypedMap, Usdc, Vault, ZapProtocol } from "../types";
+import { Address, Integer, TokenMetadata, TypedMap, Usdc, Vault, ZapProtocol } from "../types";
 import { Balance, Icon, IconMap, Token } from "../types";
 
 const TokenAbi = ["function approve(address _spender, uint256 _value) public"];
@@ -60,25 +60,31 @@ export class TokenInterface<C extends ChainId> extends ServiceInterface<C> {
    * @param address
    */
   async balances(address: Address): Promise<Balance[]> {
-    const vaultBalances = await this.yearn.vaults
-      .balances(address)
-      .then(balances => balances.filter(token => token.balance !== "0"));
+    try {
+      const vaultBalances = await this.yearn.vaults
+        .balances(address)
+        .then(balances => balances.filter(token => token.balance !== "0"));
 
-    if (this.chainId === 1 || this.chainId === 1337) {
-      let zapperBalances = await this.yearn.services.zapper.balances(address);
-      const vaultBalanceAddresses = new Set(vaultBalances.map(balance => balance.address));
-      zapperBalances = zapperBalances.filter(balance => !vaultBalanceAddresses.has(balance.address));
-      return zapperBalances.concat(vaultBalances);
+      if (this.chainId === 1 || this.chainId === 1337) {
+        let zapperBalances = await this.yearn.services.zapper.balances(address);
+        const vaultBalanceAddresses = new Set(vaultBalances.map(balance => balance.address));
+        zapperBalances = zapperBalances.filter(balance => !vaultBalanceAddresses.has(balance.address));
+        return zapperBalances.concat(vaultBalances);
+      }
+
+      if (this.chainId === 250 || this.chainId === 42161) {
+        let ironBankTokens = await this.yearn.ironBank.balances(address);
+        const vaultBalanceAddresses = new Set(vaultBalances.map(balance => balance.address));
+        ironBankTokens = ironBankTokens.filter(balance => !vaultBalanceAddresses.has(balance.address));
+        return ironBankTokens.concat(vaultBalances);
+      }
+
+      console.error(`the chain ${this.chainId} hasn't been implemented yet`);
+    } catch (error) {
+      console.error(error);
     }
 
-    if (this.chainId === 250 || this.chainId === 42161) {
-      let ironBankTokens = await this.yearn.ironBank.balances(address);
-      const vaultBalanceAddresses = new Set(vaultBalances.map(balance => balance.address));
-      ironBankTokens = ironBankTokens.filter(balance => !vaultBalanceAddresses.has(balance.address));
-      return ironBankTokens.concat(vaultBalances);
-    }
-
-    throw new SdkError(`the chain ${this.chainId} hasn't been implemented yet`);
+    return [];
   }
 
   /**
@@ -87,22 +93,29 @@ export class TokenInterface<C extends ChainId> extends ServiceInterface<C> {
    * @returns list of tokens supported by the zapper protocol.
    */
   async supported(): Promise<Token[]> {
-    const cached = await this.cachedFetcherSupported.fetch();
-    if (cached) {
-      return cached;
+    try {
+      const cached = await this.cachedFetcherSupported.fetch();
+      if (cached) {
+        return cached;
+      }
+
+      if (this.chainId === 1 || this.chainId === 1337) {
+        // only ETH Main is supported
+        const tokens = await this.yearn.services.zapper.supportedTokens();
+        const icons = await this.yearn.services.asset.ready.then(() =>
+          this.yearn.services.asset.icon(tokens.map(token => token.address))
+        );
+        return tokens.map(token => {
+          const icon = icons[token.address];
+          return icon ? { ...token, icon } : token;
+        });
+      }
+
+      console.error(`the chain ${this.chainId} hasn't been implemented yet`);
+    } catch (error) {
+      console.error(error);
     }
 
-    if (this.chainId === 1 || this.chainId === 1337) {
-      // only ETH Main is supported
-      const tokens = await this.yearn.services.zapper.supportedTokens();
-      const icons = await this.yearn.services.asset.ready.then(() =>
-        this.yearn.services.asset.icon(tokens.map(token => token.address))
-      );
-      return tokens.map(token => {
-        const icon = icons[token.address];
-        return icon ? { ...token, icon } : token;
-      });
-    }
     return [];
   }
 


### PR DESCRIPTION
Refactors a `balances()` and `supported()` to instead of throwing logging the error and returning an empty array.