### PR TITLE
refactor: Return all supported tokens in available networks [WEB-1416]

### DIFF
--- a/src/interfaces/token.spec.ts
+++ b/src/interfaces/token.spec.ts
@@ -1,6 +1,6 @@
 import { Contract } from "@ethersproject/contracts";
 
-import { Address, Asset, ChainId, TokenInterface, TokenMetadata } from "..";
+import { Address, Asset, ChainId, Token, TokenInterface, TokenMetadata } from "..";
 import { CachedFetcher } from "../cache";
 import { Context } from "../context";
 import { EthAddress } from "../helpers";
@@ -20,7 +20,9 @@ const assetIconMock = jest.fn();
 const assetReadyThenMock = jest.fn();
 const metaTokensMock = jest.fn();
 const vaultsBalancesMock = jest.fn();
+const vaultsTokensMock = jest.fn();
 const ironBankBalancesMock = jest.fn();
+const ironBankTokensMock = jest.fn();
 const sendTransactionMock = jest.fn();
 
 jest.mock("@ethersproject/contracts", () => ({
@@ -58,9 +60,10 @@ jest.mock("../yearn", () => ({
         sendTransaction: sendTransactionMock
       }
     },
-    ironBank: { balances: ironBankBalancesMock },
+    ironBank: { balances: ironBankBalancesMock, tokens: ironBankTokensMock },
     vaults: {
-      balances: vaultsBalancesMock
+      balances: vaultsBalancesMock,
+      tokens: vaultsTokensMock
     }
   }))
 }));
@@ -233,54 +236,179 @@ describe("TokenInterface", () => {
         jest.spyOn(CachedFetcher.prototype, "fetch").mockResolvedValue(undefined);
       });
 
-      describe("when chainId is 1 or 1337", () => {
-        beforeEach(() => {
-          tokenInterface = new TokenInterface(mockedYearn, 1, new Context({}));
-        });
+      ([1, 1337] as ChainId[]).forEach(chainId =>
+        describe(`when chainId is ${chainId}`, () => {
+          let ironBankToken: Token;
+          let vaultsToken: Token;
 
-        it("should fetch all the tokens supported by the zapper protocol along with icon url", async () => {
-          const supportedTokenWithIcon = createMockToken();
-          const supportedTokenWithoutIcon = createMockToken({ address: "0x002" });
-          zapperSupportedTokensMock.mockResolvedValue([supportedTokenWithIcon, supportedTokenWithoutIcon]);
-          assetReadyThenMock.mockResolvedValue({ "0x001": "image.png" });
-
-          const actualSupportedTokens = await tokenInterface.supported();
-
-          expect(actualSupportedTokens).toEqual([
-            { ...supportedTokenWithIcon, icon: "image.png" },
-            supportedTokenWithoutIcon
-          ]);
-          expect(zapperSupportedTokensMock).toHaveBeenCalledTimes(1);
-          expect(assetReadyThenMock).toHaveBeenCalledTimes(1);
-        });
-
-        it("should return an empty array when zapper fails", async () => {
-          zapperSupportedTokensMock.mockImplementation(() => {
-            throw new Error("zapper balances failed!");
+          beforeEach(() => {
+            tokenInterface = new TokenInterface(mockedYearn, chainId, new Context({}));
+            ironBankToken = createMockToken({ address: "0x001", symbol: "IRON", name: "Iron Token" });
+            vaultsToken = createMockToken({
+              address: "0x002",
+              symbol: "VAULT",
+              name: "Vault Token"
+            });
+            vaultsTokensMock.mockResolvedValue([vaultsToken]);
+            ironBankTokensMock.mockResolvedValue([ironBankToken]);
           });
 
-          const actualSupportedTokens = await tokenInterface.supported();
+          it("should fetch all the tokens from Zapper, Vaults and Iron", async () => {
+            const supportedZapperTokenWithIcon = createMockToken({ address: "0x003" });
+            const supportedZapperTokenWithoutIcon = createMockToken({ address: "0x004" });
 
-          expect(actualSupportedTokens).toEqual([]);
-          expect(zapperSupportedTokensMock).toHaveBeenCalledTimes(1);
-          expect(assetReadyThenMock).not.toHaveBeenCalled();
-          expect(console.error).toHaveBeenCalled();
-        });
-      });
+            zapperSupportedTokensMock.mockResolvedValue([
+              supportedZapperTokenWithIcon,
+              supportedZapperTokenWithoutIcon
+            ]);
+            assetReadyThenMock.mockResolvedValue({ "0x003": "image.png" });
 
-      describe("when chainId is not supported", () => {
-        beforeEach(() => {
-          tokenInterface = new TokenInterface(mockedYearn, 250, new Context({}));
-        });
+            const actualSupportedTokens = await tokenInterface.supported();
 
-        it("should return an empty array", async () => {
+            expect(actualSupportedTokens.length).toEqual(4);
+            expect(actualSupportedTokens).toEqual(
+              expect.arrayContaining([
+                { ...supportedZapperTokenWithIcon, icon: "image.png", supported: { zapper: true } },
+                { ...supportedZapperTokenWithoutIcon, supported: { zapper: true } },
+                vaultsToken,
+                ironBankToken
+              ])
+            );
+            expect(zapperSupportedTokensMock).toHaveBeenCalledTimes(1);
+            expect(vaultsTokensMock).toHaveBeenCalledTimes(1);
+            expect(ironBankTokensMock).toHaveBeenCalledTimes(1);
+            expect(assetReadyThenMock).toHaveBeenCalledTimes(1);
+          });
+
+          it("should overwrite zapper tokens' data with our own in case of duplicates", async () => {
+            const ironBankTokenAlsoInZapper = createMockToken({
+              address: "0x001",
+              symbol: "IRON",
+              name: "Iron Token in Zapper",
+              icon: "iron-bank.svg",
+              priceUsdc: "10"
+            });
+            const vaultsTokenAlsoInZapper = createMockToken({
+              address: "0x002",
+              symbol: "VAULT",
+              name: "Vault Token in Zapper",
+              icon: "vaults.svg",
+              priceUsdc: "20"
+            });
+            const ironBankTokenNotInZapper = createMockToken({
+              address: "0x003",
+              symbol: "IRON2",
+              name: "Iron Token 2",
+              icon: "iron-bank-2.svg",
+              priceUsdc: "12"
+            });
+            const vaultsTokenNotInZapper = createMockToken({
+              address: "0x004",
+              symbol: "VAULT2",
+              name: "Vault Token 2",
+              icon: "vaults-2.svg",
+              priceUsdc: "22"
+            });
+            const ironBankTokenInVaults = createMockToken({
+              address: "0x005",
+              symbol: "IRON3",
+              name: "Iron Token in Vaults",
+              icon: "iron-bank-3.svg",
+              priceUsdc: "13"
+            });
+            const vaultsTokenInIronBank = createMockToken({
+              address: "0x005",
+              symbol: "VAULT3",
+              name: "Vault Token in Iron Bank",
+              icon: "vaults-3.svg",
+              priceUsdc: "23"
+            });
+
+            ironBankTokensMock.mockResolvedValue([
+              vaultsTokenAlsoInZapper,
+              ironBankTokenNotInZapper,
+              ironBankTokenInVaults
+            ]);
+            vaultsTokensMock.mockResolvedValue([
+              ironBankTokenAlsoInZapper,
+              vaultsTokenNotInZapper,
+              vaultsTokenInIronBank
+            ]);
+            zapperSupportedTokensMock.mockResolvedValue([
+              {
+                ...ironBankTokenAlsoInZapper,
+                priceUsdc: "1",
+                supported: {
+                  zapper: true
+                }
+              },
+              {
+                ...vaultsTokenAlsoInZapper,
+                priceUsdc: "2",
+                supported: {
+                  zapper: true
+                }
+              }
+            ]);
+            assetReadyThenMock.mockResolvedValue({ "0x001": "zapper-iron-bank.svg", "0x002": "zapper-vaults.svg" });
+
+            const actualSupportedTokens = await tokenInterface.supported();
+
+            expect(actualSupportedTokens.length).toEqual(5);
+            expect(actualSupportedTokens).toEqual(
+              expect.arrayContaining([
+                {
+                  ...ironBankTokenAlsoInZapper,
+                  supported: {
+                    zapper: true
+                  }
+                },
+                vaultsTokenNotInZapper,
+                {
+                  ...vaultsTokenAlsoInZapper,
+                  supported: {
+                    zapper: true
+                  }
+                },
+                ironBankTokenNotInZapper,
+                vaultsTokenInIronBank
+              ])
+            );
+            expect(zapperSupportedTokensMock).toHaveBeenCalledTimes(1);
+            expect(vaultsTokensMock).toHaveBeenCalledTimes(1);
+            expect(ironBankTokensMock).toHaveBeenCalledTimes(1);
+            expect(assetReadyThenMock).toHaveBeenCalledTimes(1);
+          });
+
+          it("should return internal tokens when zapper fails", async () => {
+            zapperSupportedTokensMock.mockImplementation(() => {
+              throw new Error("zapper balances failed!");
+            });
+
+            const actualSupportedTokens = await tokenInterface.supported();
+
+            expect(actualSupportedTokens.length).toEqual(2);
+            expect(actualSupportedTokens).toEqual([vaultsToken, ironBankToken]);
+            expect(zapperSupportedTokensMock).toHaveBeenCalledTimes(1);
+            expect(vaultsTokensMock).toHaveBeenCalledTimes(1);
+            expect(ironBankTokensMock).toHaveBeenCalledTimes(1);
+            expect(assetReadyThenMock).not.toHaveBeenCalled();
+            expect(console.error).toHaveBeenCalled();
+          });
+        })
+      );
+
+      ([250, 42161] as ChainId[]).forEach(chainId =>
+        it(`should return an empty array when chainId is ${chainId}`, async () => {
+          tokenInterface = new TokenInterface(mockedYearn, chainId, new Context({}));
+
           const actualSupportedTokens = await tokenInterface.supported();
 
           expect(actualSupportedTokens).toEqual([]);
           expect(zapperSupportedTokensMock).not.toHaveBeenCalled();
           expect(assetReadyThenMock).not.toHaveBeenCalled();
-        });
-      });
+        })
+      );
     });
   });
 

--- a/src/interfaces/token.ts
+++ b/src/interfaces/token.ts
@@ -91,64 +91,64 @@ export class TokenInterface<C extends ChainId> extends ServiceInterface<C> {
   }
 
   /**
-   * Fetch all the tokens supported by the zapper protocol along with some basic
-   * metadata.
-   * @returns list of tokens supported by the zapper protocol.
+   * Fetch all the tokens supported along with some basic metadata.
+   * @returns list of tokens supported.
    */
   async supported(): Promise<Token[]> {
-    try {
-      const cached = await this.cachedFetcherSupported.fetch();
-      if (cached) {
-        return cached;
-      }
-
-      // Only ethereum supported
-      if (this.chainId === 1 || this.chainId === 1337) {
-        let zapperTokensWithIcon: Token[] = [];
-
-        try {
-          zapperTokensWithIcon = await this.getZapperTokensWithIcons();
-        } catch (error) {
-          console.error(error);
-        }
-
-        const vaultsTokens = await this.yearn.vaults.tokens();
-
-        const ironBankTokens = await this.yearn.ironBank.tokens();
-
-        const combinedVaultsAndIronBankTokens = this.mergeTokens(vaultsTokens, ironBankTokens);
-
-        if (!zapperTokensWithIcon.length) {
-          return combinedVaultsAndIronBankTokens;
-        }
-
-        const allSupportedTokens = this.mergeTokens(combinedVaultsAndIronBankTokens, zapperTokensWithIcon);
-
-        const zapperTokensUniqueAddresses = new Set(zapperTokensWithIcon.map(({ address }) => address));
-
-        return allSupportedTokens.map(token => {
-          const isZapperToken = zapperTokensUniqueAddresses.has(token.address);
-
-          return {
-            ...token,
-            ...(isZapperToken && {
-              supported: {
-                ...token.supported,
-                zapper: true
-              }
-            })
-          };
-        });
-      }
-
-      console.error(`the chain ${this.chainId} hasn't been implemented yet`);
-    } catch (error) {
-      console.error(error);
+    const cached = await this.cachedFetcherSupported.fetch();
+    if (cached) {
+      return cached;
     }
+
+    let zapperTokensWithIcon: Token[] = [];
+
+    // Zapper only supported in Ethereum
+    if ([1, 1337].includes(this.chainId)) {
+      try {
+        zapperTokensWithIcon = await this.getZapperTokensWithIcons();
+      } catch (error) {
+        console.error(error);
+      }
+    }
+
+    if ([1, 1337, 250, 42161].includes(this.chainId)) {
+      const vaultsTokens = await this.yearn.vaults.tokens();
+      const ironBankTokens = await this.yearn.ironBank.tokens();
+
+      const combinedVaultsAndIronBankTokens = this.mergeTokens(vaultsTokens, ironBankTokens);
+
+      if (!zapperTokensWithIcon.length) {
+        return combinedVaultsAndIronBankTokens;
+      }
+
+      const allSupportedTokens = this.mergeTokens(combinedVaultsAndIronBankTokens, zapperTokensWithIcon);
+
+      const zapperTokensUniqueAddresses = new Set(zapperTokensWithIcon.map(({ address }) => address));
+
+      return allSupportedTokens.map(token => {
+        const isZapperToken = zapperTokensUniqueAddresses.has(token.address);
+
+        return {
+          ...token,
+          ...(isZapperToken && {
+            supported: {
+              ...token.supported,
+              zapper: true
+            }
+          })
+        };
+      });
+    }
+
+    console.error(`the chain ${this.chainId} hasn't been implemented yet`);
 
     return [];
   }
 
+  /**
+   * Fetches supported zapper tokens and sets their icon
+   * @returns zapper tokens with icons
+   */
   private async getZapperTokensWithIcons(): Promise<Token[]> {
     const zapperTokens = await this.yearn.services.zapper.supportedTokens();
 

--- a/src/interfaces/vault.spec.ts
+++ b/src/interfaces/vault.spec.ts
@@ -646,9 +646,7 @@ describe("VaultInterface", () => {
               symbol: "DEAD",
               name: "Dead Token",
               priceUsdc: "0",
-              supported: {
-                zapper: true
-              }
+              supported: {}
             },
             name: "Dead Token",
             priceUsdc: "1",

--- a/src/services/zapper.spec.ts
+++ b/src/services/zapper.spec.ts
@@ -1,6 +1,6 @@
 import { getAddress } from "@ethersproject/address";
 
-import { ChainId, Context, SdkError, ZapperService } from "..";
+import { ChainId, Context, ZapperService } from "..";
 import { Chains } from "../chain";
 import { createMockZapperToken } from "../test-utils/factories";
 
@@ -19,19 +19,11 @@ jest.mock("@ethersproject/address", () => ({
 describe("ZapperService", () => {
   let zapperServiceService: ZapperService;
 
-  ([1, 1337] as ChainId[]).forEach(chainId =>
+  ([1, 1337, 250, 42161] as ChainId[]).forEach(chainId =>
     it(`should not throw when chainId is ${chainId}`, () => {
       expect(() => {
         zapperServiceService = new ZapperService(chainId, new Context({}));
-      }).not.toThrow(new SdkError(`Chain id ${chainId} currently not supported!`));
-    })
-  );
-
-  ([250, 42161] as ChainId[]).forEach(chainId =>
-    it(`should throw when chainId is ${chainId}`, () => {
-      expect(() => {
-        zapperServiceService = new ZapperService(chainId, new Context({}));
-      }).toThrow(new SdkError(`Chain id ${chainId} currently not supported!`));
+      }).not.toThrow();
     })
   );
 

--- a/src/services/zapper.spec.ts
+++ b/src/services/zapper.spec.ts
@@ -1,0 +1,83 @@
+import { getAddress } from "@ethersproject/address";
+
+import { ChainId, Context, SdkError, ZapperService } from "..";
+import { Chains } from "../chain";
+import { createMockZapperToken } from "../test-utils/factories";
+
+const fetchSpy = jest.spyOn(global, "fetch");
+
+const getAddressMock = jest.fn();
+
+jest.mock("../context", () => ({
+  Context: jest.fn().mockImplementation(() => ({}))
+}));
+
+jest.mock("@ethersproject/address", () => ({
+  getAddress: jest.fn(() => getAddressMock())
+}));
+
+describe("ZapperService", () => {
+  let zapperServiceService: ZapperService;
+
+  ([1, 1337] as ChainId[]).forEach(chainId =>
+    it(`should not throw when chainId is ${chainId}`, () => {
+      expect(() => {
+        zapperServiceService = new ZapperService(chainId, new Context({}));
+      }).not.toThrow(new SdkError(`Chain id ${chainId} currently not supported!`));
+    })
+  );
+
+  ([250, 42161] as ChainId[]).forEach(chainId =>
+    it(`should throw when chainId is ${chainId}`, () => {
+      expect(() => {
+        zapperServiceService = new ZapperService(chainId, new Context({}));
+      }).toThrow(new SdkError(`Chain id ${chainId} currently not supported!`));
+    })
+  );
+
+  describe("supportedTokens", () => {
+    ([1, 1337] as ChainId[]).forEach(chainId =>
+      describe(`when chainId is ${chainId}`, () => {
+        beforeEach(() => {
+          zapperServiceService = new ZapperService(chainId, new Context({}));
+        });
+
+        it("should return the only visible tokens", async () => {
+          const mockZapperToken = createMockZapperToken();
+          const mockHiddenZapperToken = createMockZapperToken({
+            symbol: "SHY",
+            hide: true
+          });
+
+          fetchSpy.mockImplementation(
+            jest.fn(() =>
+              Promise.resolve({
+                json: () => Promise.resolve([mockZapperToken, mockHiddenZapperToken]),
+                status: 200
+              })
+            ) as jest.Mock
+          );
+          getAddressMock.mockReturnValue("0x001");
+
+          const actualSupportedTokens = await zapperServiceService.supportedTokens();
+
+          expect(actualSupportedTokens.length).toEqual(1);
+          expect(actualSupportedTokens).toEqual(
+            expect.arrayContaining([
+              {
+                address: "0x001",
+                decimals: "18",
+                icon: `https://assets.yearn.network/tokens/${Chains[chainId]}/${mockZapperToken.address}.png`,
+                name: "DEAD",
+                priceUsdc: "10000",
+                supported: { zapper: true },
+                symbol: "DEAD"
+              }
+            ])
+          );
+          expect(getAddress).toHaveBeenCalledWith("0x001");
+        });
+      })
+    );
+  });
+});

--- a/src/services/zapper.ts
+++ b/src/services/zapper.ts
@@ -1,10 +1,9 @@
 import { getAddress } from "@ethersproject/address";
 
-import { ChainId, Chains } from "../chain";
+import { Chains } from "../chain";
 import { Service } from "../common";
-import { Context } from "../context";
 import { EthAddress, handleHttpError, usdc, ZeroAddress } from "../helpers";
-import { Address, Balance, BalancesMap, Integer, SdkError, Token, ZapperToken } from "../types";
+import { Address, Balance, BalancesMap, Integer, Token, ZapperToken } from "../types";
 import {
   GasPrice,
   ZapApprovalStateOutput,
@@ -20,14 +19,6 @@ const ZAPPER_AFFILIATE_ADDRESS = "0xFEB4acf3df3cDEA7399794D0869ef76A6EfAff52";
  * tokens and user positions.
  */
 export class ZapperService extends Service {
-  constructor(chainId: ChainId, ctx: Context) {
-    super(chainId, ctx);
-
-    if (![1, 1337].includes(chainId)) {
-      throw new SdkError(`Chain id ${chainId} currently not supported!`);
-    }
-  }
-
   /**
    * Fetch all the tokens supported by the zapper protocol along with some basic
    * metadata.

--- a/src/services/zapper.ts
+++ b/src/services/zapper.ts
@@ -1,9 +1,10 @@
 import { getAddress } from "@ethersproject/address";
 
-import { Chains } from "../chain";
+import { ChainId, Chains } from "../chain";
 import { Service } from "../common";
+import { Context } from "../context";
 import { EthAddress, handleHttpError, usdc, ZeroAddress } from "../helpers";
-import { Address, Balance, BalancesMap, Integer, Token } from "../types";
+import { Address, Balance, BalancesMap, Integer, SdkError, Token, ZapperToken } from "../types";
 import {
   GasPrice,
   ZapApprovalStateOutput,
@@ -19,6 +20,14 @@ const ZAPPER_AFFILIATE_ADDRESS = "0xFEB4acf3df3cDEA7399794D0869ef76A6EfAff52";
  * tokens and user positions.
  */
 export class ZapperService extends Service {
+  constructor(chainId: ChainId, ctx: Context) {
+    super(chainId, ctx);
+
+    if (![1, 1337].includes(chainId)) {
+      throw new SdkError(`Chain id ${chainId} currently not supported!`);
+    }
+  }
+
   /**
    * Fetch all the tokens supported by the zapper protocol along with some basic
    * metadata.
@@ -27,22 +36,26 @@ export class ZapperService extends Service {
   async supportedTokens(): Promise<Token[]> {
     const url = "https://api.zapper.fi/v1/prices";
     const params = new URLSearchParams({ api_key: this.ctx.zapper });
-    const tokens = await fetch(`${url}?${params}`)
+    const zapperTokens: ZapperToken[] = await fetch(`${url}?${params}`)
       .then(handleHttpError)
       .then(res => res.json());
-    const network = Chains[this.chainId] ?? "ethereum";
-    return tokens.map(
-      (token: Record<string, string>): Token => {
-        const address = token.address === ZeroAddress ? EthAddress : getAddress(String(token.address));
-        const supported = token.hide ? !token.hide : true;
+
+    const network = Chains[this.chainId];
+
+    const visibleZapperTokens = zapperTokens.filter(zapperToken => !zapperToken.hide);
+
+    return visibleZapperTokens.map(
+      (zapperToken): Token => {
+        const address = zapperToken.address === ZeroAddress ? EthAddress : getAddress(zapperToken.address);
+
         return {
-          address: address,
-          name: token.symbol,
-          symbol: token.symbol,
-          icon: `https://assets.yearn.network/tokens/${network}/${token.address}.png`,
-          decimals: token.decimals,
-          priceUsdc: usdc(token.price),
-          supported: { zapper: supported }
+          address,
+          decimals: String(zapperToken.decimals),
+          icon: `https://assets.yearn.network/tokens/${network}/${address}.png`,
+          name: zapperToken.symbol,
+          priceUsdc: usdc(zapperToken.price),
+          supported: { zapper: true },
+          symbol: zapperToken.symbol
         };
       }
     );

--- a/src/test-utils/factories/index.ts
+++ b/src/test-utils/factories/index.ts
@@ -7,3 +7,4 @@ export * from "./earningsAssetData.factory";
 export * from "./earningsUserData.factory";
 export * from "./token.factory";
 export * from "./tokenBalance.factory";
+export * from "./zapperToken.factory";

--- a/src/test-utils/factories/token.factory.ts
+++ b/src/test-utils/factories/token.factory.ts
@@ -6,9 +6,7 @@ const DEFAULT_TOKEN: Token = {
   symbol: "DEAD",
   name: "Dead Token",
   priceUsdc: "0",
-  supported: {
-    zapper: true
-  }
+  supported: {}
 };
 
 export const createMockToken = (overwrites: Partial<Token> = {}) => ({

--- a/src/test-utils/factories/zapperToken.factory.ts
+++ b/src/test-utils/factories/zapperToken.factory.ts
@@ -1,0 +1,14 @@
+import { ZapperToken } from "../../types";
+
+const DEFAULT_ZAPPER_TOKEN: ZapperToken = {
+  address: "0x001",
+  decimals: 18,
+  symbol: "DEAD",
+  price: 0.01,
+  hide: undefined
+};
+
+export const createMockZapperToken = (overwrites: Partial<ZapperToken> = {}) => ({
+  ...DEFAULT_ZAPPER_TOKEN,
+  ...overwrites
+});

--- a/src/types/asset.ts
+++ b/src/types/asset.ts
@@ -28,6 +28,15 @@ export interface Token extends ERC20 {
   metadata?: TokenMetadata;
 }
 
+export interface ZapperToken {
+  address: string;
+  canExchange?: boolean;
+  decimals: number;
+  hide?: boolean;
+  price: number;
+  symbol: string;
+}
+
 /**
  * Representation of a user position in a particular asset.
  */


### PR DESCRIPTION
[WEB-1416](https://linear.app/yearn/issue/WEB-1416/tokeninterfacesupported-should-return-all-supported-tokens) (subtask of [WEB-1008](https://linear.app/yearn/issue/WEB-1008/supported-tokens-by-network))

Refactors `TokenInterface#supported()` to return all supported tokens not only from Zapper but also from Vaults and Iron Bank for the current network. At the moment zapper only works for Ethereum, but we return the Vaults and Iron Bank tokens for the other networks i.e. Fantom and Arbitrum.

- Deduplicates tokens giving higher priority to tokens coming from Vaults, then Iron Bank and Zapper respectively, always preserving the zapper support in cases where the zapper token is in other products;
- Fails gracefully if zapper is not available, returning the supported tokens from Vaults and Iron Bank;
- Add specs to cover all cases (please let me know if you spot an edge case missing and I'll add the test for it).