### PR TITLE
refactor: TokenInterface#balances [WEB-1420]

### DIFF
--- a/src/interfaces/ironbank.ts
+++ b/src/interfaces/ironbank.ts
@@ -162,7 +162,7 @@ export class IronBankInterface<T extends ChainId> extends ServiceInterface<T> {
     const erc20ToToken: (erc20Token: ERC20) => Promise<Token> = async (erc20Token: ERC20) => ({
       ...erc20Token,
       icon: icons[erc20Token.address],
-      dataSource: "ironbank" as TokenDataSource,
+      dataSource: "ironBank" as TokenDataSource,
       supported: {
         ironBank: true
       },

--- a/src/interfaces/token.spec.ts
+++ b/src/interfaces/token.spec.ts
@@ -155,6 +155,11 @@ describe("TokenInterface", () => {
       name: "vaultToken",
       dataSource: "vaults"
     });
+    const vaultTokenNoBalance = createMockToken({
+      address: "0x000",
+      name: "vaultToken without balance",
+      dataSource: "vaults"
+    });
     const ironBankToken = createMockToken({
       address: "0x002",
       name: "ironBankToken",
@@ -169,6 +174,13 @@ describe("TokenInterface", () => {
       address: "0x001",
       token: createMockToken({
         name: "vaultTokenWithBalance"
+      })
+    });
+    const vaultTokenWithoutBalance = createMockBalance({
+      address: "0x000",
+      balance: "0",
+      token: createMockToken({
+        name: "vaultTokenWithoutBalance"
       })
     });
     const ironBankTokenWithBalance = createMockBalance({
@@ -188,11 +200,13 @@ describe("TokenInterface", () => {
       describe(`when chainId is ${chainId}`, () => {
         beforeEach(() => {
           tokenInterface = new TokenInterface(mockedYearn, chainId, new Context({}));
-          tokenInterface.supported = jest.fn().mockResolvedValue([vaultToken, ironBankToken, zapperToken]);
+          tokenInterface.supported = jest
+            .fn()
+            .mockResolvedValue([vaultToken, vaultTokenNoBalance, ironBankToken, zapperToken]);
         });
 
         it("should return balances for all supported tokens", async () => {
-          vaultsBalancesMock.mockResolvedValue([vaultTokenWithBalance]);
+          vaultsBalancesMock.mockResolvedValue([vaultTokenWithBalance, vaultTokenWithoutBalance]);
           ironBankBalancesMock.mockResolvedValue([ironBankTokenWithBalance]);
           zapperBalancesMock.mockResolvedValue([zapperTokenWithBalance]);
 
@@ -208,7 +222,7 @@ describe("TokenInterface", () => {
         });
 
         it("should filter supported tokens when address list is given", async () => {
-          vaultsBalancesMock.mockResolvedValue([vaultTokenWithBalance]);
+          vaultsBalancesMock.mockResolvedValue([vaultTokenWithBalance, vaultTokenWithoutBalance]);
           ironBankBalancesMock.mockResolvedValue([ironBankTokenWithBalance]);
           zapperBalancesMock.mockResolvedValue([zapperTokenWithBalance]);
 
@@ -225,7 +239,7 @@ describe("TokenInterface", () => {
           zapperBalancesMock.mockImplementation(() => {
             throw new Error("zapper balances failed!");
           });
-          vaultsBalancesMock.mockResolvedValue([vaultTokenWithBalance]);
+          vaultsBalancesMock.mockResolvedValue([vaultTokenWithBalance, vaultTokenWithoutBalance]);
           ironBankBalancesMock.mockResolvedValue([ironBankTokenWithBalance]);
 
           const actualBalances = await tokenInterface.balances("0xAccount", [vaultToken.address]);
@@ -242,11 +256,11 @@ describe("TokenInterface", () => {
       describe(`when chainId is ${chainId}`, () => {
         beforeEach(() => {
           tokenInterface = new TokenInterface(mockedYearn, chainId, new Context({}));
-          tokenInterface.supported = jest.fn().mockResolvedValue([vaultToken, ironBankToken]);
+          tokenInterface.supported = jest.fn().mockResolvedValue([vaultToken, vaultTokenNoBalance, ironBankToken]);
         });
 
         it("should return balances for all supported tokens", async () => {
-          vaultsBalancesMock.mockResolvedValue([vaultTokenWithBalance]);
+          vaultsBalancesMock.mockResolvedValue([vaultTokenWithBalance, vaultTokenWithoutBalance]);
           ironBankBalancesMock.mockResolvedValue([ironBankTokenWithBalance]);
 
           const actualBalances = await tokenInterface.balances("0xAccount");
@@ -259,7 +273,7 @@ describe("TokenInterface", () => {
         });
 
         it("should filter supported tokens when address list is given", async () => {
-          vaultsBalancesMock.mockResolvedValue([vaultTokenWithBalance]);
+          vaultsBalancesMock.mockResolvedValue([vaultTokenWithBalance, vaultTokenWithoutBalance]);
           ironBankBalancesMock.mockResolvedValue([ironBankTokenWithBalance]);
 
           const actualBalances = await tokenInterface.balances("0xAccount", [vaultToken.address]);
@@ -277,7 +291,7 @@ describe("TokenInterface", () => {
       beforeEach(() => {
         tokenInterface = new TokenInterface(mockedYearn, 42 as ChainId, new Context({}));
         zapperBalancesMock.mockResolvedValue([zapperTokenWithBalance]);
-        vaultsBalancesMock.mockResolvedValue([vaultTokenWithBalance]);
+        vaultsBalancesMock.mockResolvedValue([vaultTokenWithBalance, vaultTokenWithoutBalance]);
         ironBankBalancesMock.mockResolvedValue([ironBankTokenWithBalance]);
       });
 

--- a/src/interfaces/token.spec.ts
+++ b/src/interfaces/token.spec.ts
@@ -163,7 +163,7 @@ describe("TokenInterface", () => {
     const ironBankToken = createMockToken({
       address: "0x002",
       name: "ironBankToken",
-      dataSource: "ironbank"
+      dataSource: "ironBank"
     });
     const zapperToken = createMockToken({
       address: "0x003",

--- a/src/interfaces/token.ts
+++ b/src/interfaces/token.ts
@@ -109,7 +109,7 @@ export class TokenInterface<C extends ChainId> extends ServiceInterface<C> {
     if ([1, 1337, 250, 42161].includes(this.chainId)) {
       const vaultBalances = await this.yearn.vaults.balances(account);
       balances.vaults = vaultBalances.filter(
-        ({ address, balance }) => addresses.vaults.has(address) && balance !== "0"
+        ({ address, balance }) => balance !== "0" && addresses.vaults.has(address)
       );
 
       let ironBankBalances = await this.yearn.ironBank.balances(account);

--- a/src/interfaces/token.ts
+++ b/src/interfaces/token.ts
@@ -100,7 +100,8 @@ export class TokenInterface<C extends ChainId> extends ServiceInterface<C> {
     const balances: SourceBalances = {
       zapper: [],
       vaults: [],
-      ironBank: []
+      ironBank: [],
+      labs: []
     };
 
     if ([1, 1337].includes(this.chainId)) {

--- a/src/interfaces/token.ts
+++ b/src/interfaces/token.ts
@@ -112,7 +112,7 @@ export class TokenInterface<C extends ChainId> extends ServiceInterface<C> {
         ({ address, balance }) => balance !== "0" && addresses.vaults.has(address)
       );
 
-      let ironBankBalances = await this.yearn.ironBank.balances(account);
+      const ironBankBalances = await this.yearn.ironBank.balances(account);
       balances.ironBank = ironBankBalances.filter(({ address }) => addresses.ironBank.has(address));
 
       return [...balances.vaults, ...balances.ironBank, ...balances.zapper];

--- a/src/interfaces/token.ts
+++ b/src/interfaces/token.ts
@@ -14,7 +14,6 @@ import {
   SourceAddresses,
   SourceBalances,
   TokenAllowance,
-  TokenDataSource,
   TokenMetadata,
   TypedMap,
   Usdc,
@@ -85,11 +84,18 @@ export class TokenInterface<C extends ChainId> extends ServiceInterface<C> {
       tokens = tokens.filter(({ address }) => tokenAddresses.includes(address));
     }
 
-    const addresses: SourceAddresses = {
-      zapper: this.getAddressesBySource({ tokens, source: "zapper" }),
-      vaults: this.getAddressesBySource({ tokens, source: "vaults" }),
-      ironBank: this.getAddressesBySource({ tokens, source: "ironbank" })
-    };
+    const addresses: SourceAddresses = tokens.reduce(
+      (acc, { address, dataSource }) => {
+        acc[dataSource].add(address);
+        return acc;
+      },
+      {
+        zapper: new Set<Address>(),
+        vaults: new Set<Address>(),
+        ironBank: new Set<Address>(),
+        labs: new Set<Address>()
+      }
+    );
 
     const balances: SourceBalances = {
       zapper: [],
@@ -382,12 +388,5 @@ export class TokenInterface<C extends ChainId> extends ServiceInterface<C> {
     const filter = new Set(a.map(({ address }) => address));
 
     return [...a, ...b.filter(({ address }) => !filter.has(address))];
-  }
-
-  private getAddressesBySource({ tokens, source }: { tokens: Token[]; source: TokenDataSource }): Set<Address> {
-    const bySource = ({ dataSource }: Token) => dataSource === source;
-    const toAddress = ({ address }: Token) => address;
-
-    return new Set(tokens.filter(bySource).map(toAddress));
   }
 }

--- a/src/interfaces/vault.spec.ts
+++ b/src/interfaces/vault.spec.ts
@@ -670,7 +670,10 @@ describe("VaultInterface", () => {
             },
             name: "Dead Token",
             priceUsdc: "1",
-            supported: {}
+            dataSource: "vaults",
+            supported: {
+              vaults: true
+            }
           }
         ]);
         expect(lensAdaptersVaultsV2TokensMock).toHaveBeenCalledTimes(1);

--- a/src/interfaces/vault.spec.ts
+++ b/src/interfaces/vault.spec.ts
@@ -666,6 +666,7 @@ describe("VaultInterface", () => {
               symbol: "DEAD",
               name: "Dead Token",
               priceUsdc: "0",
+              dataSource: "vaults",
               supported: {}
             },
             name: "Dead Token",

--- a/src/interfaces/vault.ts
+++ b/src/interfaces/vault.ts
@@ -283,7 +283,10 @@ export class VaultInterface<T extends ChainId> extends ServiceInterface<T> {
             const result: Token = {
               ...token,
               icon: icons[token.address],
-              supported: {},
+              dataSource: "vaults",
+              supported: {
+                vaults: true
+              },
               priceUsdc: await this.yearn.services.oracle.getPriceUsdc(token.address, overrides),
               metadata: tokenMetadata
             };

--- a/src/services/zapper.spec.ts
+++ b/src/services/zapper.spec.ts
@@ -62,6 +62,7 @@ describe("ZapperService", () => {
                 icon: `https://assets.yearn.network/tokens/${Chains[chainId]}/${mockZapperToken.address}.png`,
                 name: "DEAD",
                 priceUsdc: "10000",
+                dataSource: "zapper",
                 supported: { zapper: true },
                 symbol: "DEAD"
               }

--- a/src/services/zapper.ts
+++ b/src/services/zapper.ts
@@ -45,6 +45,7 @@ export class ZapperService extends Service {
           icon: `https://assets.yearn.network/tokens/${network}/${address}.png`,
           name: zapperToken.symbol,
           priceUsdc: usdc(zapperToken.price),
+          dataSource: "zapper",
           supported: { zapper: true },
           symbol: zapperToken.symbol
         };

--- a/src/test-utils/factories/token.factory.ts
+++ b/src/test-utils/factories/token.factory.ts
@@ -6,6 +6,7 @@ const DEFAULT_TOKEN: Token = {
   symbol: "DEAD",
   name: "Dead Token",
   priceUsdc: "0",
+  dataSource: "vaults",
   supported: {}
 };
 

--- a/src/types/asset.ts
+++ b/src/types/asset.ts
@@ -93,4 +93,4 @@ export type Asset<T extends TypeId> = AssetStatic<T> & AssetDynamic<T> & { typeI
  */
 export type GenericAsset = Asset<"VAULT_V1"> | Asset<"VAULT_V2"> | Asset<"IRON_BANK_MARKET">;
 
-export type TokenDataSource = "vaults" | "ironbank" | "zapper" | "labs";
+export type TokenDataSource = "vaults" | "ironBank" | "zapper" | "labs";

--- a/src/types/asset.ts
+++ b/src/types/asset.ts
@@ -22,8 +22,12 @@ export interface TokenAmount {
 export interface Token extends ERC20 {
   icon?: string;
   priceUsdc: Usdc;
+  dataSource: TokenDataSource;
   supported: {
     zapper?: boolean;
+    vaults?: boolean;
+    ironBank?: boolean;
+    labs?: boolean;
   };
   metadata?: TokenMetadata;
 }
@@ -88,3 +92,5 @@ export type Asset<T extends TypeId> = AssetStatic<T> & AssetDynamic<T> & { typeI
  * Possible assets that lens can return.
  */
 export type GenericAsset = Asset<"VAULT_V1"> | Asset<"VAULT_V2"> | Asset<"IRON_BANK_MARKET">;
+
+export type TokenDataSource = "vaults" | "ironbank" | "zapper" | "labs";

--- a/src/types/custom/token.ts
+++ b/src/types/custom/token.ts
@@ -34,10 +34,12 @@ export interface SourceAddresses {
   zapper: Set<Address>;
   vaults: Set<Address>;
   ironBank: Set<Address>;
+  labs: Set<Address>;
 }
 
 export interface SourceBalances {
   zapper: Balance[];
   vaults: Balance[];
   ironBank: Balance[];
+  labs: Balance[];
 }

--- a/src/types/custom/token.ts
+++ b/src/types/custom/token.ts
@@ -29,3 +29,15 @@ export interface Balance {
 }
 
 export type BalancesMap<T extends Address> = TypedMap<T, Balance[]>;
+
+export interface SourceAddresses {
+  zapper: Set<Address>;
+  vaults: Set<Address>;
+  ironBank: Set<Address>;
+}
+
+export interface SourceBalances {
+  zapper: Balance[];
+  vaults: Balance[];
+  ironBank: Balance[];
+}


### PR DESCRIPTION
[WEB-1420](https://linear.app/yearn/issue/WEB-1420/[sdk]-refactor-tokeninterfacebalances) (subtask of [WEB-1008](https://linear.app/yearn/issue/WEB-1008/supported-tokens-by-network))

- ✅ Fails gracefully when there is an error with zapper;
- ✅ Merge balances following same precedence (vaults > iron bank > zapper) and remove dupes
- ✅ If a token is not supported it throws an error
- ✅ If token addresses list is not provided, return balances for all supported tokens (i.e. `Token.supported()`)

Add a new type for token data source, it will be set to the service where the token data came from.

`type TokenDataSource = "vaults" | "ironbank" | "zapper" | "labs";`

Add a few props to the `Token` interface
```typescript
interface Token extends ERC20 {
  // ...
  dataSource: TokenDataSource; // new
  supported: {
    zapper?: boolean;
    vaults?: boolean; // new
    ironBank?: boolean; // new
    labs?: boolean; // new
  };
  // ...
}
```
