### PR TITLE
refactor: TokenInterface#priceUsdc

### DIFF
--- a/src/interfaces/token.spec.ts
+++ b/src/interfaces/token.spec.ts
@@ -1,7 +1,7 @@
 import { MaxUint256 } from "@ethersproject/constants";
 import { Contract } from "@ethersproject/contracts";
 
-import { Address, Asset, ChainId, Token, TokenInterface, TokenMetadata } from "..";
+import { Address, Asset, ChainId, SdkError, Token, TokenInterface, TokenMetadata } from "..";
 import { CachedFetcher } from "../cache";
 import { Context } from "../context";
 import { EthAddress } from "../helpers";
@@ -145,14 +145,15 @@ describe("TokenInterface", () => {
       expect(getPriceUsdcMock).toHaveBeenNthCalledWith(2, "0x001", undefined);
     });
 
-    it("should return `null` and log an error when network is not supported", async () => {
+    it("should throw when network is not supported", async () => {
       tokenInterface = new TokenInterface(mockedYearn, 42 as ChainId, new Context({}));
 
-      const actualPriceUsdc = await tokenInterface.priceUsdc(["0x000", "0x001"]);
-
-      expect(actualPriceUsdc).toEqual(null);
-      expect(getPriceUsdcMock).not.toHaveBeenCalled();
-      expect(console.error).toHaveBeenCalledWith("the chain 42 hasn't been implemented yet");
+      try {
+        await tokenInterface.priceUsdc(["0x000", "0x001"]);
+      } catch (error) {
+        expect(error).toStrictEqual(new SdkError("the chain 42 hasn't been implemented yet"));
+        expect(getPriceUsdcMock).not.toHaveBeenCalled();
+      }
     });
   });
 

--- a/src/interfaces/token.spec.ts
+++ b/src/interfaces/token.spec.ts
@@ -144,6 +144,16 @@ describe("TokenInterface", () => {
       expect(getPriceUsdcMock).toHaveBeenNthCalledWith(1, "0x000", undefined);
       expect(getPriceUsdcMock).toHaveBeenNthCalledWith(2, "0x001", undefined);
     });
+
+    it("should return `null` and log an error when network is not supported", async () => {
+      tokenInterface = new TokenInterface(mockedYearn, 42 as ChainId, new Context({}));
+
+      const actualPriceUsdc = await tokenInterface.priceUsdc(["0x000", "0x001"]);
+
+      expect(actualPriceUsdc).toEqual(null);
+      expect(getPriceUsdcMock).not.toHaveBeenCalled();
+      expect(console.error).toHaveBeenCalledWith("the chain 42 hasn't been implemented yet");
+    });
   });
 
   describe("balances", () => {

--- a/src/interfaces/token.ts
+++ b/src/interfaces/token.ts
@@ -35,7 +35,7 @@ export class TokenInterface<C extends ChainId> extends ServiceInterface<C> {
    * @param overrides
    * @returns Usdc exchange rate (6 decimals)
    */
-  async priceUsdc<T extends Address>(token: T, overrides?: CallOverrides): Promise<Usdc>;
+  async priceUsdc<T extends Address>(token: T, overrides?: CallOverrides): Promise<Usdc | null>;
 
   /**
    * Get the suggested Usdc exchange rate for list of tokens.
@@ -43,7 +43,7 @@ export class TokenInterface<C extends ChainId> extends ServiceInterface<C> {
    * @param overrides
    * @returns Usdc exchange rate map (6 decimals)
    */
-  async priceUsdc<T extends Address>(tokens: T[], overrides?: CallOverrides): Promise<TypedMap<T, Usdc>>;
+  async priceUsdc<T extends Address>(tokens: T[], overrides?: CallOverrides): Promise<TypedMap<T, Usdc> | null>;
 
   async priceUsdc<T extends Address>(
     tokens: T | T[],

--- a/src/interfaces/token.ts
+++ b/src/interfaces/token.ts
@@ -8,7 +8,17 @@ import { ChainId, Chains } from "../chain";
 import { ServiceInterface } from "../common";
 import { EthAddress } from "../helpers";
 import { PickleJars } from "../services/partners/pickle";
-import { Address, Integer, TokenAllowance, TokenMetadata, TypedMap, Usdc, Vault, ZapProtocol } from "../types";
+import {
+  Address,
+  Integer,
+  SdkError,
+  TokenAllowance,
+  TokenMetadata,
+  TypedMap,
+  Usdc,
+  Vault,
+  ZapProtocol
+} from "../types";
 import { Balance, Icon, IconMap, Token } from "../types";
 
 const TokenAbi = [
@@ -35,7 +45,7 @@ export class TokenInterface<C extends ChainId> extends ServiceInterface<C> {
    * @param overrides
    * @returns Usdc exchange rate (6 decimals)
    */
-  async priceUsdc<T extends Address>(token: T, overrides?: CallOverrides): Promise<Usdc | null>;
+  async priceUsdc<T extends Address>(token: T, overrides?: CallOverrides): Promise<Usdc>;
 
   /**
    * Get the suggested Usdc exchange rate for list of tokens.
@@ -43,15 +53,11 @@ export class TokenInterface<C extends ChainId> extends ServiceInterface<C> {
    * @param overrides
    * @returns Usdc exchange rate map (6 decimals)
    */
-  async priceUsdc<T extends Address>(tokens: T[], overrides?: CallOverrides): Promise<TypedMap<T, Usdc> | null>;
+  async priceUsdc<T extends Address>(tokens: T[], overrides?: CallOverrides): Promise<TypedMap<T, Usdc>>;
 
-  async priceUsdc<T extends Address>(
-    tokens: T | T[],
-    overrides?: CallOverrides
-  ): Promise<TypedMap<T, Usdc> | Usdc | null> {
+  async priceUsdc<T extends Address>(tokens: T | T[], overrides?: CallOverrides): Promise<TypedMap<T, Usdc> | Usdc> {
     if (!Chains[this.chainId]) {
-      console.error(`the chain ${this.chainId} hasn't been implemented yet`);
-      return null;
+      throw new SdkError(`the chain ${this.chainId} hasn't been implemented yet`);
     }
 
     if (Array.isArray(tokens)) {

--- a/src/interfaces/token.ts
+++ b/src/interfaces/token.ts
@@ -4,7 +4,7 @@ import { TransactionRequest, TransactionResponse } from "@ethersproject/provider
 import BigNumber from "bignumber.js";
 
 import { CachedFetcher } from "../cache";
-import { ChainId } from "../chain";
+import { ChainId, Chains } from "../chain";
 import { ServiceInterface } from "../common";
 import { EthAddress } from "../helpers";
 import { PickleJars } from "../services/partners/pickle";
@@ -45,7 +45,15 @@ export class TokenInterface<C extends ChainId> extends ServiceInterface<C> {
    */
   async priceUsdc<T extends Address>(tokens: T[], overrides?: CallOverrides): Promise<TypedMap<T, Usdc>>;
 
-  async priceUsdc<T extends Address>(tokens: T | T[], overrides?: CallOverrides): Promise<TypedMap<T, Usdc> | Usdc> {
+  async priceUsdc<T extends Address>(
+    tokens: T | T[],
+    overrides?: CallOverrides
+  ): Promise<TypedMap<T, Usdc> | Usdc | null> {
+    if (!Chains[this.chainId]) {
+      console.error(`the chain ${this.chainId} hasn't been implemented yet`);
+      return null;
+    }
+
     if (Array.isArray(tokens)) {
       const entries = await Promise.all(
         tokens.map(async token => {


### PR DESCRIPTION
[WEB-1425](https://linear.app/yearn/issue/WEB-1425) (subtask of [WEB-1008](https://linear.app/yearn/issue/WEB-1008/supported-tokens-by-network))

`sdk.tokens.priceUsdc(addresses)` should return price for the given token addresses if they are supported in current network.