### PR TITLE
fix: convert earnings timestamps to milliseconds

### DIFF
--- a/src/helpers.spec.ts
+++ b/src/helpers.spec.ts
@@ -1,4 +1,4 @@
-import { anyTimestampToMillis, chunkArray } from "./helpers";
+import { chunkArray, convertSecondsMillisOrMicrosToMillis } from "./helpers";
 
 describe("Helpers", () => {
   describe("chunkArray", () => {
@@ -49,40 +49,44 @@ describe("Helpers", () => {
   describe("anyTimestampToMillis", () => {
     describe("with string input", () => {
       it("should convert a unix timestamp from seconds to millis", () => {
-        expect(anyTimestampToMillis("9999999999")).toEqual(9999999999000);
-        expect(anyTimestampToMillis("1000000000")).toEqual(1000000000000);
-        expect(anyTimestampToMillis("0000000001")).toEqual(1000);
+        expect(convertSecondsMillisOrMicrosToMillis("9999999999")).toEqual(9999999999000);
+        expect(convertSecondsMillisOrMicrosToMillis("1000000000")).toEqual(1000000000000);
+        expect(convertSecondsMillisOrMicrosToMillis("0000000001")).toEqual(1000);
       });
       it("should convert a unix timestamp from microseconds to millis", () => {
-        expect(anyTimestampToMillis("9999999999999000")).toEqual(9999999999999);
-        expect(anyTimestampToMillis("1000000000000000")).toEqual(1000000000000);
-        expect(anyTimestampToMillis("0000000001000000")).toEqual(1000);
+        expect(convertSecondsMillisOrMicrosToMillis("9999999999999000")).toEqual(9999999999999);
+        expect(convertSecondsMillisOrMicrosToMillis("1000000000000000")).toEqual(1000000000000);
+        expect(convertSecondsMillisOrMicrosToMillis("0000000001000000")).toEqual(1000);
       });
       it("should keep timestamps in millis intact", () => {
-        expect(anyTimestampToMillis("9999999999999")).toEqual(9999999999999);
-        expect(anyTimestampToMillis("1000000000000")).toEqual(1000000000000);
-        expect(anyTimestampToMillis("0000000001000")).toEqual(1000);
+        expect(convertSecondsMillisOrMicrosToMillis("9999999999999")).toEqual(9999999999999);
+        expect(convertSecondsMillisOrMicrosToMillis("1000000000000")).toEqual(1000000000000);
+        expect(convertSecondsMillisOrMicrosToMillis("0000000001000")).toEqual(1000);
       });
       it("should throw in case of too long numbers", () => {
-        expect(() => anyTimestampToMillis("10000000000000000")).toThrowError("Timestamp in invalid format");
+        expect(() => convertSecondsMillisOrMicrosToMillis("10000000000000000")).toThrowError(
+          "Timestamp in invalid format"
+        );
       });
     });
     describe("with number input", () => {
       it("should convert a unix timestamp from seconds to millis", () => {
-        expect(anyTimestampToMillis(9999999999)).toEqual(9999999999000);
-        expect(anyTimestampToMillis(1000000000)).toEqual(1000000000000);
-        expect(anyTimestampToMillis(1)).toEqual(1000);
+        expect(convertSecondsMillisOrMicrosToMillis(9999999999)).toEqual(9999999999000);
+        expect(convertSecondsMillisOrMicrosToMillis(1000000000)).toEqual(1000000000000);
+        expect(convertSecondsMillisOrMicrosToMillis(1)).toEqual(1000);
       });
       it("should convert a unix timestamp from microseconds to millis", () => {
-        expect(anyTimestampToMillis(9999999999999000)).toEqual(9999999999999);
-        expect(anyTimestampToMillis(1000000000000000)).toEqual(1000000000000);
+        expect(convertSecondsMillisOrMicrosToMillis(9999999999999000)).toEqual(9999999999999);
+        expect(convertSecondsMillisOrMicrosToMillis(1000000000000000)).toEqual(1000000000000);
       });
       it("should keep timestamps in millis intact", () => {
-        expect(anyTimestampToMillis(9999999999999)).toEqual(9999999999999);
-        expect(anyTimestampToMillis(1000000000000)).toEqual(1000000000000);
+        expect(convertSecondsMillisOrMicrosToMillis(9999999999999)).toEqual(9999999999999);
+        expect(convertSecondsMillisOrMicrosToMillis(1000000000000)).toEqual(1000000000000);
       });
       it("should throw in case of too long numbers", () => {
-        expect(() => anyTimestampToMillis(10000000000000000)).toThrowError("Timestamp in invalid format");
+        expect(() => convertSecondsMillisOrMicrosToMillis(10000000000000000)).toThrowError(
+          "Timestamp in invalid format"
+        );
       });
     });
   });

--- a/src/helpers.spec.ts
+++ b/src/helpers.spec.ts
@@ -1,4 +1,4 @@
-import { chunkArray } from "./helpers";
+import { anyTimestampToMillis, chunkArray } from "./helpers";
 
 describe("Helpers", () => {
   describe("chunkArray", () => {
@@ -42,6 +42,47 @@ describe("Helpers", () => {
           expect(chunkedArray.length).toBe(1);
           expect(chunkedArray).toEqual([[1, 2, 3, 4, 5, 6]]);
         });
+      });
+    });
+  });
+
+  describe("anyTimestampToMillis", () => {
+    describe("with string input", () => {
+      it("should convert a unix timestamp from seconds to millis", () => {
+        expect(anyTimestampToMillis("9999999999")).toEqual(9999999999000);
+        expect(anyTimestampToMillis("1000000000")).toEqual(1000000000000);
+        expect(anyTimestampToMillis("0000000001")).toEqual(1000);
+      });
+      it("should convert a unix timestamp from microseconds to millis", () => {
+        expect(anyTimestampToMillis("9999999999999000")).toEqual(9999999999999);
+        expect(anyTimestampToMillis("1000000000000000")).toEqual(1000000000000);
+        expect(anyTimestampToMillis("0000000001000000")).toEqual(1000);
+      });
+      it("should keep timestamps in millis intact", () => {
+        expect(anyTimestampToMillis("9999999999999")).toEqual(9999999999999);
+        expect(anyTimestampToMillis("1000000000000")).toEqual(1000000000000);
+        expect(anyTimestampToMillis("0000000001000")).toEqual(1000);
+      });
+      it("should throw in case of too long numbers", () => {
+        expect(() => anyTimestampToMillis("10000000000000000")).toThrowError("Timestamp in invalid format");
+      });
+    });
+    describe("with number input", () => {
+      it("should convert a unix timestamp from seconds to millis", () => {
+        expect(anyTimestampToMillis(9999999999)).toEqual(9999999999000);
+        expect(anyTimestampToMillis(1000000000)).toEqual(1000000000000);
+        expect(anyTimestampToMillis(1)).toEqual(1000);
+      });
+      it("should convert a unix timestamp from microseconds to millis", () => {
+        expect(anyTimestampToMillis(9999999999999000)).toEqual(9999999999999);
+        expect(anyTimestampToMillis(1000000000000000)).toEqual(1000000000000);
+      });
+      it("should keep timestamps in millis intact", () => {
+        expect(anyTimestampToMillis(9999999999999)).toEqual(9999999999999);
+        expect(anyTimestampToMillis(1000000000000)).toEqual(1000000000000);
+      });
+      it("should throw in case of too long numbers", () => {
+        expect(() => anyTimestampToMillis(10000000000000000)).toThrowError("Timestamp in invalid format");
       });
     });
   });

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -44,7 +44,8 @@ export function anyTimestampToMillis(timestamp: string | number): number {
   const testMillis = /^\d{13}$/;
   const testMicros = /^\d{16}$/;
 
-  const input = typeof timestamp === "string" ? timestamp : timestamp.toString();
+  let input = typeof timestamp === "string" ? timestamp : timestamp.toString();
+  input = input.padStart(10, "0"); // optional padding in case of a number input
   if (testMillis.test(input)) {
     return +timestamp;
   } else if (testMicros.test(input)) {

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -37,3 +37,21 @@ export function chunkArray<T>(array: T[], size: number) {
   }
   return result;
 }
+
+// converts timestamps from second and microsecond format to milliseconds
+export function anyTimestampToMillis(timestamp: string | number): number {
+  const testSeconds = /^\d{10}$/;
+  const testMillis = /^\d{13}$/;
+  const testMicros = /^\d{16}$/;
+
+  const input = typeof timestamp === "string" ? timestamp : timestamp.toString();
+  if (testMillis.test(input)) {
+    return +timestamp;
+  } else if (testMicros.test(input)) {
+    return +timestamp / 1000;
+  } else if (testSeconds.test(input)) {
+    return +timestamp * 1000;
+  } else {
+    throw new Error("Timestamp in invalid format");
+  }
+}

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -39,7 +39,7 @@ export function chunkArray<T>(array: T[], size: number) {
 }
 
 // converts timestamps from second and microsecond format to milliseconds
-export function anyTimestampToMillis(timestamp: string | number): number {
+export function convertSecondsMillisOrMicrosToMillis(timestamp: string | number): number {
   const testSeconds = /^\d{10}$/;
   const testMillis = /^\d{13}$/;
   const testMicros = /^\d{16}$/;

--- a/src/interfaces/earnings.ts
+++ b/src/interfaces/earnings.ts
@@ -4,6 +4,7 @@ import { BigNumber } from "bignumber.js";
 import { CachedFetcher } from "../cache";
 import { ChainId } from "../chain";
 import { ServiceInterface } from "../common";
+import { anyTimestampToMillis } from "../helpers";
 import {
   ACCOUNT_EARNINGS,
   ACCOUNT_HISTORIC_EARNINGS,
@@ -257,7 +258,7 @@ export class EarningsInterface<C extends ChainId> extends ServiceInterface<C> {
           amountUsdc: amountUsdc.toFixed(0),
           amount: amountEarnt.toFixed(0)
         },
-        date: new Date(+data[label].vaultDayData[0].timestamp).toJSON()
+        date: new Date(anyTimestampToMillis(data[label].vaultDayData[0].timestamp)).toJSON()
       };
 
       return dayData;
@@ -317,14 +318,14 @@ export class EarningsInterface<C extends ChainId> extends ServiceInterface<C> {
     const updates = vaultPositions
       .flatMap(vaultPosition => vaultPosition.updates)
       .sort((lhs, rhs) => {
-        return +lhs.timestamp - +rhs.timestamp;
+        return anyTimestampToMillis(+lhs.timestamp - +rhs.timestamp);
       });
 
     for (const [index, vaultPositionUpdate] of updates.entries()) {
       if (index === 0) {
         const snapshot: AccountSnapshot = {
           startDate: new Date(0),
-          endDate: new Date(+vaultPositionUpdate.timestamp),
+          endDate: new Date(anyTimestampToMillis(vaultPositionUpdate.timestamp)),
           deposits: new BigNumber(vaultPositionUpdate.deposits),
           withdrawals: new BigNumber(vaultPositionUpdate.withdrawals),
           tokensReceived: new BigNumber(vaultPositionUpdate.tokensReceived),
@@ -336,7 +337,7 @@ export class EarningsInterface<C extends ChainId> extends ServiceInterface<C> {
         const previousSnapshot = snapshotTimeline[index - 1];
         const snapshot: AccountSnapshot = {
           startDate: previousSnapshot.endDate,
-          endDate: new Date(+vaultPositionUpdate.timestamp),
+          endDate: new Date(anyTimestampToMillis(vaultPositionUpdate.timestamp)),
           deposits: previousSnapshot.deposits.plus(new BigNumber(vaultPositionUpdate.deposits)),
           withdrawals: previousSnapshot.withdrawals.plus(new BigNumber(vaultPositionUpdate.withdrawals)),
           tokensReceived: previousSnapshot.tokensReceived.plus(new BigNumber(vaultPositionUpdate.tokensReceived)),
@@ -368,7 +369,7 @@ export class EarningsInterface<C extends ChainId> extends ServiceInterface<C> {
 
     const earningsDayData = await Promise.all(
       vaultDayData.map(async vaultDayDatum => {
-        const date = new Date(+vaultDayDatum.timestamp);
+        const date = new Date(anyTimestampToMillis(vaultDayDatum.timestamp));
         const snapshot = snapshotTimeline.find(snapshot => date >= snapshot.startDate && date < snapshot.endDate);
         if (snapshot) {
           const balanceTokens = snapshot.balanceShares

--- a/src/interfaces/earnings.ts
+++ b/src/interfaces/earnings.ts
@@ -4,7 +4,7 @@ import { BigNumber } from "bignumber.js";
 import { CachedFetcher } from "../cache";
 import { ChainId } from "../chain";
 import { ServiceInterface } from "../common";
-import { anyTimestampToMillis } from "../helpers";
+import { convertSecondsMillisOrMicrosToMillis } from "../helpers";
 import {
   ACCOUNT_EARNINGS,
   ACCOUNT_HISTORIC_EARNINGS,
@@ -258,7 +258,7 @@ export class EarningsInterface<C extends ChainId> extends ServiceInterface<C> {
           amountUsdc: amountUsdc.toFixed(0),
           amount: amountEarnt.toFixed(0)
         },
-        date: new Date(anyTimestampToMillis(data[label].vaultDayData[0].timestamp)).toJSON()
+        date: new Date(convertSecondsMillisOrMicrosToMillis(data[label].vaultDayData[0].timestamp)).toJSON()
       };
 
       return dayData;
@@ -318,14 +318,14 @@ export class EarningsInterface<C extends ChainId> extends ServiceInterface<C> {
     const updates = vaultPositions
       .flatMap(vaultPosition => vaultPosition.updates)
       .sort((lhs, rhs) => {
-        return anyTimestampToMillis(+lhs.timestamp - +rhs.timestamp);
+        return convertSecondsMillisOrMicrosToMillis(+lhs.timestamp - +rhs.timestamp);
       });
 
     for (const [index, vaultPositionUpdate] of updates.entries()) {
       if (index === 0) {
         const snapshot: AccountSnapshot = {
           startDate: new Date(0),
-          endDate: new Date(anyTimestampToMillis(vaultPositionUpdate.timestamp)),
+          endDate: new Date(convertSecondsMillisOrMicrosToMillis(vaultPositionUpdate.timestamp)),
           deposits: new BigNumber(vaultPositionUpdate.deposits),
           withdrawals: new BigNumber(vaultPositionUpdate.withdrawals),
           tokensReceived: new BigNumber(vaultPositionUpdate.tokensReceived),
@@ -337,7 +337,7 @@ export class EarningsInterface<C extends ChainId> extends ServiceInterface<C> {
         const previousSnapshot = snapshotTimeline[index - 1];
         const snapshot: AccountSnapshot = {
           startDate: previousSnapshot.endDate,
-          endDate: new Date(anyTimestampToMillis(vaultPositionUpdate.timestamp)),
+          endDate: new Date(convertSecondsMillisOrMicrosToMillis(vaultPositionUpdate.timestamp)),
           deposits: previousSnapshot.deposits.plus(new BigNumber(vaultPositionUpdate.deposits)),
           withdrawals: previousSnapshot.withdrawals.plus(new BigNumber(vaultPositionUpdate.withdrawals)),
           tokensReceived: previousSnapshot.tokensReceived.plus(new BigNumber(vaultPositionUpdate.tokensReceived)),
@@ -369,7 +369,7 @@ export class EarningsInterface<C extends ChainId> extends ServiceInterface<C> {
 
     const earningsDayData = await Promise.all(
       vaultDayData.map(async vaultDayDatum => {
-        const date = new Date(anyTimestampToMillis(vaultDayDatum.timestamp));
+        const date = new Date(convertSecondsMillisOrMicrosToMillis(vaultDayDatum.timestamp));
         const snapshot = snapshotTimeline.find(snapshot => date >= snapshot.startDate && date < snapshot.endDate);
         if (snapshot) {
           const balanceTokens = snapshot.balanceShares


### PR DESCRIPTION
Adds a helper function that converts timestamps from seconds and microseconds to millis.

Fixes #244