### PR TITLE
fix: make partnerId optional in context

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -72,7 +72,8 @@ const DefaultContext: ContextValue = {
   zapper: "96e0cc51-a62e-42ca-acee-910ea7d2a241",
   // The default tenderly dashboard for Yearn
   simulation: { dashboardUrl: "https://dashboard.tenderly.co/yearn/yearn-web" },
-  cache: { useCache: true, url: "https://cache.yearn.finance" }
+  cache: { useCache: true, url: "https://cache.yearn.finance" },
+  partnerId: ""
 };
 
 /**

--- a/src/context.ts
+++ b/src/context.ts
@@ -72,8 +72,7 @@ const DefaultContext: ContextValue = {
   zapper: "96e0cc51-a62e-42ca-acee-910ea7d2a241",
   // The default tenderly dashboard for Yearn
   simulation: { dashboardUrl: "https://dashboard.tenderly.co/yearn/yearn-web" },
-  cache: { useCache: true, url: "https://cache.yearn.finance" },
-  partnerId: ""
+  cache: { useCache: true, url: "https://cache.yearn.finance" }
 };
 
 /**
@@ -84,7 +83,7 @@ const DefaultContext: ContextValue = {
  * [[Context]] **should not** be instantiated by users, as it's managed by
  * {@link Yearn.context}.
  */
-export class Context implements Required<ContextValue> {
+export class Context implements ContextValue {
   static PROVIDER = "refresh:provider";
 
   private ctx: ContextValue;
@@ -152,8 +151,7 @@ export class Context implements Required<ContextValue> {
     throw new SdkError("subgraph configuration must be defined in Context for this feature to work.");
   }
 
-  get partnerId(): string {
-    if (typeof this.ctx.partnerId !== "undefined") return this.ctx.partnerId;
-    throw new SdkError("partnerId must be defined in Context for this feature to work.");
+  get partnerId(): string | undefined {
+    return this.ctx.partnerId;
   }
 }

--- a/src/services/partner.spec.ts
+++ b/src/services/partner.spec.ts
@@ -29,13 +29,17 @@ jest.mock("./addressProvider", () => ({
 
 describe("PartnerService", () => {
   let partner: PartnerService<1>;
+  let partnerId: string;
+  let context: Context;
   let mockedAddressProvider: AddressProvider<ChainId>;
   let encodeFunctionDataMock: jest.Mock;
   let depositMock: jest.Mock;
 
   beforeEach(() => {
     mockedAddressProvider = new ((AddressProvider as unknown) as jest.Mock<AddressProvider<ChainId>>)();
-    partner = new PartnerService(1, new Context({}), mockedAddressProvider);
+    partnerId = "partnerid";
+    context = new Context({ partnerId: partnerId });
+    partner = new PartnerService(1, context, mockedAddressProvider, partnerId);
     encodeFunctionDataMock = jest.fn();
     depositMock = jest.fn();
     Object.defineProperty(partner, "_getContract", {

--- a/src/services/partner.ts
+++ b/src/services/partner.ts
@@ -31,9 +31,9 @@ export class PartnerService<T extends ChainId> extends ContractService<T> {
     })();
   }
 
-  constructor(chainId: T, ctx: Context, addressProvider: AddressProvider<T>) {
+  constructor(chainId: T, ctx: Context, addressProvider: AddressProvider<T>, partnerId: string) {
     super(chainId, ctx, addressProvider);
-    this.partnerId = ctx.partnerId;
+    this.partnerId = partnerId;
   }
 
   isAllowed(vault: string) {

--- a/src/yearn.ts
+++ b/src/yearn.ts
@@ -148,7 +148,7 @@ export class Yearn<T extends ChainId> {
       meta: new MetaService(chainId, ctx),
       allowList: allowlistService,
       transaction: new TransactionService(chainId, ctx, allowlistService),
-      partner: new PartnerService(chainId, ctx, addressProvider)
+      partner: ctx.partnerId ? new PartnerService(chainId, ctx, addressProvider) : undefined
     };
   }
 }

--- a/src/yearn.ts
+++ b/src/yearn.ts
@@ -148,7 +148,7 @@ export class Yearn<T extends ChainId> {
       meta: new MetaService(chainId, ctx),
       allowList: allowlistService,
       transaction: new TransactionService(chainId, ctx, allowlistService),
-      partner: ctx.partnerId ? new PartnerService(chainId, ctx, addressProvider) : undefined
+      partner: ctx.partnerId ? new PartnerService(chainId, ctx, addressProvider, ctx.partnerId) : undefined
     };
   }
 }


### PR DESCRIPTION
Previously the SDK immediately crashed when instantiated without a `partnerId` being provided in the `Context` object. `partnerId` should be something not required to use the SDK. 

We need to give it a value because `export class Context implements Required<ContextValue> {` uses `Required`, so it can't be optional. Although maybe we should remove this limitation