### PR TITLE
fix: throw an error when allow list address is the zero address

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -85,9 +85,11 @@ export class ContractService<T extends ChainId, E = {}> extends Service<E> {
 
     try {
       const address = await this.addressProvider.addressById(contractId);
+      // TODO - check whether `address` is zero, if it is then throw an error.
+      // Needs to be handled appropriately wherever this function is used
       return new WrappedContract(address, abi, ctx);
     } catch (e) {
-      console.error(`Contract address for ${contractId} is missing from Address Provider`);
+      console.error(`Contract address for ${contractId} is missing from the Address Provider`);
       throw e;
     }
   }

--- a/src/services/allowlist.spec.ts
+++ b/src/services/allowlist.spec.ts
@@ -49,7 +49,7 @@ describe("validateCalldata", () => {
       expect(actual).toEqual({ success: false, error: "can't validate a tx that has no call data" });
     });
 
-    it("should throw when contract address is `ZeroAddress`", async () => {
+    it("should return `true` and log warn message when contract address is `ZeroAddress`", async () => {
       jest.spyOn(AddressProvider.prototype, "addressById").mockResolvedValue(ZeroAddress);
 
       const actual = await allowListService.validateCalldata("0x00", "callData");

--- a/src/services/allowlist.spec.ts
+++ b/src/services/allowlist.spec.ts
@@ -94,7 +94,7 @@ describe("validateCalldata", () => {
 
         expect(actual).toEqual({ success: true, error: undefined });
         expect(consoleErrorSpy).toHaveBeenCalledWith(
-          "Contract address for ALLOW_LIST_REGISTRY is missing from Address Provider"
+          "Contract address for ALLOW_LIST_REGISTRY is missing from the Address Provider"
         );
         expect(consoleWarnSpy).toHaveBeenCalledWith(
           "AllowList on-chain contract address missing. Skipping validation..."

--- a/src/services/allowlist.spec.ts
+++ b/src/services/allowlist.spec.ts
@@ -1,4 +1,5 @@
 import { Context } from "..";
+import { ZeroAddress } from "../helpers";
 import { AddressProvider } from "./addressProvider";
 import { AllowListService } from "./allowlist";
 
@@ -25,6 +26,7 @@ describe("validateCalldata", () => {
 
   beforeEach(() => {
     allowListService = new AllowListService(1, new Context({}), addressProvider);
+    jest.spyOn(console, "warn").mockImplementation();
   });
 
   afterEach(() => {
@@ -45,6 +47,15 @@ describe("validateCalldata", () => {
       const actual = await allowListService.validateCalldata("0x00", undefined);
 
       expect(actual).toEqual({ success: false, error: "can't validate a tx that has no call data" });
+    });
+
+    it("should throw when contract address is `ZeroAddress`", async () => {
+      jest.spyOn(AddressProvider.prototype, "addressById").mockResolvedValue(ZeroAddress);
+
+      const actual = await allowListService.validateCalldata("0x00", "callData");
+
+      expect(actual).toEqual({ success: true });
+      expect(console.warn).toHaveBeenCalledWith("AllowList on-chain contract address missing. Skipping validation...");
     });
 
     describe("when it reads from the contract", () => {

--- a/src/services/allowlist.ts
+++ b/src/services/allowlist.ts
@@ -2,6 +2,7 @@ import { BytesLike } from "@ethersproject/bytes";
 
 import { ChainId } from "../chain";
 import { ContractAddressId, ContractService, WrappedContract } from "../common";
+import { ZeroAddress } from "../helpers";
 import { Address } from "../types";
 
 /**
@@ -46,7 +47,9 @@ export class AllowListService<T extends ChainId> extends ContractService<T> {
 
     try {
       contract = await this.contract;
-      if (!contract) throw new Error("Contract missing");
+      if (!contract || contract.address === ZeroAddress) {
+        throw new Error("Contract missing");
+      }
     } catch (e) {
       // temporary workaround after deprecating the `disableAllowlist` param
       // if allowlist has no onchain contract address, we skip validation altogether


### PR DESCRIPTION
## Description
The address being fetched from the address provider for the AllowList service on mainnet is missing from the address provider. However there is no check for the zero address, so the validation always fails

## Related Issue
When trying to deposit/withdraw on mainnet the following error happens: 

![telegram-cloud-photo-size-4-5895619775663552672-x](https://user-images.githubusercontent.com/19509999/159541802-35251b33-1681-4f5b-9b8c-e833a51954c4.jpg)

## Motivation and Context
To be able to deposit/withdraw

## How Has This Been Tested?
Running it with a local version of the website
