### PR TITLE
fix: use lowercase address for zapper icon url

### DIFF
--- a/src/services/zapper.ts
+++ b/src/services/zapper.ts
@@ -42,7 +42,8 @@ export class ZapperService extends Service {
         return {
           address,
           decimals: String(zapperToken.decimals),
-          icon: `https://assets.yearn.network/tokens/${network}/${address}.png`,
+          // addresses in the icon url should always be lowercase to be fetched correctly
+          icon: `https://assets.yearn.network/tokens/${network}/${zapperToken.address}.png`,
           name: zapperToken.symbol,
           priceUsdc: usdc(zapperToken.price),
           dataSource: "zapper",


### PR DESCRIPTION
## Description
Use lowercased addresses when building icon urls (in the state they are fetched from zapper)

## Related Issue
![telegram-cloud-photo-size-1-5048613445632633402-y](https://user-images.githubusercontent.com/19509999/160472840-13927361-b86d-4fdf-a386-92f56f788293.jpg)

e.g.
https://assets.yearn.network/tokens/ethereum/0xc770eefad204b5180df6a14ee197d99d808ee52d.png
https://assets.yearn.network/tokens/ethereum/0xc770EEfAd204B5180dF6a14Ee197D99d808ee52d.png

the checksummed link does not work

## Motivation and Context
https://github.com/yearn/yearn-sdk/pull/249/files broke fetching the icons for some tokens

## How Has This Been Tested?
By verifying that lowercased addresses in urls are able to be loaded correctly
