### PR TITLE
refactor: allowance and deposit use cases for vault and token interfaces

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -61,6 +61,9 @@ export enum ContractAddressId {
   helper = "HELPER",
   allowlist = "ALLOW_LIST_REGISTRY",
   partner = "PARTNER_TRACKER",
+  zapperZapIn = "ZAPPER_ZAP_IN",
+  zapperZapOut = "ZAPPER_ZAP_OUT",
+  pickleZapIn = "PICKLE_ZAP_IN",
   unused = "UNUSED"
 }
 

--- a/src/helpers.spec.ts
+++ b/src/helpers.spec.ts
@@ -1,4 +1,4 @@
-import { chunkArray, convertSecondsMillisOrMicrosToMillis } from "./helpers";
+import { chunkArray, convertSecondsMillisOrMicrosToMillis, EthAddress, isNativeToken, ZeroAddress } from "./helpers";
 
 describe("Helpers", () => {
   describe("chunkArray", () => {
@@ -87,6 +87,27 @@ describe("Helpers", () => {
         expect(() => convertSecondsMillisOrMicrosToMillis(10000000000000000)).toThrowError(
           "Timestamp in invalid format"
         );
+      });
+    });
+  });
+
+  describe("isNativeToken", () => {
+    describe("with EthAddress", () => {
+      it("should be truthy", () => {
+        const result = isNativeToken(EthAddress);
+        expect(result).toBeTruthy();
+      });
+    });
+    describe("with ZeroAddress", () => {
+      it("should be truthy", () => {
+        const result = isNativeToken(ZeroAddress);
+        expect(result).toBeTruthy();
+      });
+    });
+    describe("with non native address", () => {
+      it("should be falsy", () => {
+        const result = isNativeToken("0xNonNative");
+        expect(result).toBeFalsy();
       });
     });
   });

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,10 +1,15 @@
 import { BigNumber } from "@ethersproject/bignumber";
 
-import { Integer, SdkError, Usdc } from "./types";
+import { Address, Integer, SdkError, Usdc } from "./types";
 
 export const ZeroAddress = "0x0000000000000000000000000000000000000000";
 export const EthAddress = "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE";
 export const WethAddress = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2";
+
+// Returns truthy if address is defined as a native token address of a network
+export function isNativeToken(address: Address): boolean {
+  return address === EthAddress || address === ZeroAddress;
+}
 
 // handle a non-200 `fetch` response.
 export async function handleHttpError(response: Response): Promise<Response> {

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -8,7 +8,7 @@ export const WethAddress = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2";
 
 // Returns truthy if address is defined as a native token address of a network
 export function isNativeToken(address: Address): boolean {
-  return address === EthAddress || address === ZeroAddress;
+  return [EthAddress, ZeroAddress].includes(address);
 }
 
 // handle a non-200 `fetch` response.

--- a/src/interfaces/token.spec.ts
+++ b/src/interfaces/token.spec.ts
@@ -631,6 +631,17 @@ describe("TokenInterface", () => {
         expect(sendTransactionMock).not.toHaveBeenCalled();
       }
     });
+
+    it("should throw if approving token as its spender", async () => {
+      try {
+        await tokenInterface.approve(owner, spender, spender, amount);
+      } catch (error) {
+        expect(error).toStrictEqual(new SdkError(`Cant approve token as its spender`));
+        expect(Contract).not.toHaveBeenCalled();
+        expect(approveMock).not.toHaveBeenCalled();
+        expect(sendTransactionMock).not.toHaveBeenCalled();
+      }
+    });
   });
 
   describe("allowance", () => {

--- a/src/interfaces/token.spec.ts
+++ b/src/interfaces/token.spec.ts
@@ -1,11 +1,11 @@
 import { MaxUint256 } from "@ethersproject/constants";
 import { Contract } from "@ethersproject/contracts";
 
-import { Address, Asset, ChainId, Integer, SdkError, Token, TokenInterface, TokenMetadata } from "..";
+import { Address, ChainId, Integer, SdkError, Token, TokenInterface, TokenMetadata } from "..";
 import { CachedFetcher } from "../cache";
 import { Context } from "../context";
 import { ZeroAddress } from "../helpers";
-import { createMockAssetStaticVaultV2, createMockBalance, createMockToken } from "../test-utils/factories";
+import { createMockBalance, createMockToken } from "../test-utils/factories";
 import { Yearn } from "../yearn";
 
 const getPriceUsdcMock = jest.fn();
@@ -680,77 +680,6 @@ describe("TokenInterface", () => {
       expect(allowanceResult).toEqual(allowance);
       expect(Contract).not.toBeCalled();
       expect(allowanceMock).not.toBeCalled();
-    });
-  });
-
-  describe("approveZapOut", () => {
-    describe("when the vault token is not the same as the token", () => {
-      let vault: Asset<"VAULT_V2">;
-      let token: Address;
-
-      beforeEach(() => {
-        vault = createMockAssetStaticVaultV2();
-        token = createMockToken({ address: "0x999" }).address;
-      });
-
-      it("should return false", async () => {
-        const actualApproveZapOut = await tokenInterface.approveZapOut(vault, token, "0x001");
-
-        expect(actualApproveZapOut).toEqual(false);
-      });
-    });
-
-    describe("zapInApprovalState", () => {
-      let vault: Asset<"VAULT_V2">;
-      let token: Address;
-
-      beforeEach(() => {
-        vault = createMockAssetStaticVaultV2();
-        token = createMockToken().address;
-        zapperGasMock.mockResolvedValue({
-          standard: 1,
-          instant: 2,
-          fast: 3
-        });
-      });
-
-      describe("when is not approved", () => {
-        beforeEach(() => {
-          zapperZapOutApprovalStateMock.mockResolvedValue({
-            isApproved: false
-          });
-          zapperZapOutApprovalTransactionMock.mockResolvedValue({
-            data: "data",
-            to: "0x000",
-            from: "0x001",
-            gasPrice: "1"
-          });
-        });
-
-        it("should approve vault to spend a vault token on zapOut", async () => {
-          const actualApproveZapOut = await tokenInterface.approveZapOut(vault, token, "0x001");
-
-          expect(actualApproveZapOut).toEqual("transaction");
-          expect(zapperZapOutApprovalStateMock).toHaveBeenCalledTimes(1);
-          expect(zapperZapOutApprovalStateMock).toHaveBeenCalledWith("0x001", "0x001");
-          expect(zapperZapOutApprovalTransactionMock).toHaveBeenCalledTimes(1);
-          expect(zapperZapOutApprovalTransactionMock).toHaveBeenCalledWith("0x001", "0x001", "3000000000");
-        });
-      });
-
-      describe("when is approved", () => {
-        beforeEach(() => {
-          zapperZapOutApprovalStateMock.mockResolvedValue({
-            isApproved: true
-          });
-        });
-
-        it("should return false", async () => {
-          const actualApproveZapOut = await tokenInterface.approveZapOut(vault, token, "0x001");
-
-          expect(actualApproveZapOut).toEqual(false);
-        });
-      });
     });
   });
 

--- a/src/interfaces/token.spec.ts
+++ b/src/interfaces/token.spec.ts
@@ -95,8 +95,11 @@ jest.mock("../context", () => ({
 }));
 
 describe("TokenInterface", () => {
+  const owner: Address = "0xOwner";
+  const spender: Address = "0xSpender";
+  const token: Address = "0xToken";
+  const amount: Integer = "1000000";
   let tokenInterface: TokenInterface<1>;
-
   let mockedYearn: Yearn<ChainId>;
 
   beforeEach(() => {
@@ -589,13 +592,7 @@ describe("TokenInterface", () => {
   });
 
   describe("approve", () => {
-    const owner: Address = "0xOwner";
-    const spender: Address = "0xSpender";
-    const amount: Integer = "1000000";
-    let token: Address;
-
     beforeEach(() => {
-      token = createMockToken().address;
       sendTransactionMock.mockResolvedValue(true);
     });
 
@@ -645,15 +642,6 @@ describe("TokenInterface", () => {
   });
 
   describe("allowance", () => {
-    const owner: Address = "0xOwner";
-    const spender: Address = "0xSpender";
-    const amount: Integer = "1000000";
-    let token: Address;
-
-    beforeEach(() => {
-      token = createMockToken().address;
-    });
-
     it("should return allowance when is a non native token", async () => {
       const allowance = { owner, token, spender, amount };
       allowanceMock.mockReturnValue(amount);

--- a/src/interfaces/token.spec.ts
+++ b/src/interfaces/token.spec.ts
@@ -622,7 +622,7 @@ describe("TokenInterface", () => {
       try {
         await tokenInterface.approve(ownerAddress, ZeroAddress, spenderAddress, amount);
       } catch (error) {
-        expect(error).toStrictEqual(new SdkError(`Native tokens cant be approved`));
+        expect(error).toStrictEqual(new SdkError(`Native tokens cant be approved: ${ZeroAddress}`));
         expect(Contract).not.toHaveBeenCalled();
         expect(approveMock).not.toHaveBeenCalled();
         expect(sendTransactionMock).not.toHaveBeenCalled();
@@ -633,7 +633,7 @@ describe("TokenInterface", () => {
       try {
         await tokenInterface.approve(ownerAddress, spenderAddress, spenderAddress, amount);
       } catch (error) {
-        expect(error).toStrictEqual(new SdkError(`Cant approve token as its spender`));
+        expect(error).toStrictEqual(new SdkError(`Cant approve token as its spender: ${spenderAddress}`));
         expect(Contract).not.toHaveBeenCalled();
         expect(approveMock).not.toHaveBeenCalled();
         expect(sendTransactionMock).not.toHaveBeenCalled();

--- a/src/interfaces/token.spec.ts
+++ b/src/interfaces/token.spec.ts
@@ -830,7 +830,7 @@ describe("TokenInterface", () => {
           "function approve(address _spender, uint256 _value) public",
           "function allowance(address _owner, address _spender) public view returns (uint256)"
         ],
-        "reader"
+        expect.any(Object)
       );
       expect(allowanceMock).toHaveBeenCalledTimes(1);
       expect(allowanceMock).toHaveBeenCalledWith(ownerAddress, spenderAddress);

--- a/src/interfaces/token.spec.ts
+++ b/src/interfaces/token.spec.ts
@@ -634,6 +634,45 @@ describe("TokenInterface", () => {
     });
   });
 
+  describe("_allowance", () => {
+    const owner: Address = "0xOwner";
+    const spender: Address = "0xSpender";
+    const amount: Integer = "1000000";
+    let token: Address;
+
+    beforeEach(() => {
+      token = createMockToken().address;
+    });
+
+    it("should return allowance when is a non native token", async () => {
+      const allowance = { owner, token, spender, amount };
+      allowanceMock.mockReturnValue(amount);
+      const allowanceResult = await tokenInterface._allowance(owner, token, spender);
+
+      expect(allowanceResult).toEqual(allowance);
+      expect(Contract).toHaveBeenCalledTimes(1);
+      expect(Contract).toHaveBeenCalledWith(
+        token,
+        [
+          "function approve(address _spender, uint256 _value) public",
+          "function allowance(address _owner, address _spender) public view returns (uint256)"
+        ],
+        "reader"
+      );
+      expect(allowanceMock).toHaveBeenCalledTimes(1);
+      expect(allowanceMock).toHaveBeenCalledWith(owner, spender);
+    });
+
+    it("should return max allowance when is a native token", async () => {
+      const allowance = { owner, token: ZeroAddress, spender, amount: MaxUint256.toString() };
+      const allowanceResult = await tokenInterface._allowance(owner, ZeroAddress, spender);
+
+      expect(allowanceResult).toEqual(allowance);
+      expect(Contract).not.toBeCalled();
+      expect(allowanceMock).not.toBeCalled();
+    });
+  });
+
   describe("approve", () => {
     describe("when the vault token is the same as the token", () => {
       let vault: Asset<"VAULT_V2">;

--- a/src/interfaces/token.spec.ts
+++ b/src/interfaces/token.spec.ts
@@ -95,9 +95,9 @@ jest.mock("../context", () => ({
 }));
 
 describe("TokenInterface", () => {
-  const owner: Address = "0xOwner";
-  const spender: Address = "0xSpender";
-  const token: Address = "0xToken";
+  const ownerAddress: Address = "0xOwner";
+  const spenderAddress: Address = "0xSpender";
+  const tokenAddress: Address = "0xToken";
   const amount: Integer = "1000000";
   let tokenInterface: TokenInterface<1>;
   let mockedYearn: Yearn<ChainId>;
@@ -598,12 +598,12 @@ describe("TokenInterface", () => {
 
     it("should return a transaction response when approving non native token", async () => {
       approveMock.mockReturnValue("approved");
-      const approveResult = await tokenInterface.approve(owner, token, spender, amount);
+      const approveResult = await tokenInterface.approve(ownerAddress, tokenAddress, spenderAddress, amount);
 
       expect(approveResult).toEqual(true);
       expect(Contract).toHaveBeenCalledTimes(1);
       expect(Contract).toHaveBeenCalledWith(
-        token,
+        tokenAddress,
         [
           "function approve(address _spender, uint256 _value) public",
           "function allowance(address _owner, address _spender) public view returns (uint256)"
@@ -613,14 +613,14 @@ describe("TokenInterface", () => {
         }
       );
       expect(approveMock).toHaveBeenCalledTimes(1);
-      expect(approveMock).toHaveBeenCalledWith(spender, amount, undefined);
+      expect(approveMock).toHaveBeenCalledWith(spenderAddress, amount, undefined);
       expect(sendTransactionMock).toHaveBeenCalledTimes(1);
       expect(sendTransactionMock).toHaveBeenCalledWith("approved");
     });
 
     it("should throw when approving native token", async () => {
       try {
-        await tokenInterface.approve(owner, ZeroAddress, spender, amount);
+        await tokenInterface.approve(ownerAddress, ZeroAddress, spenderAddress, amount);
       } catch (error) {
         expect(error).toStrictEqual(new SdkError(`Native tokens cant be approved`));
         expect(Contract).not.toHaveBeenCalled();
@@ -631,7 +631,7 @@ describe("TokenInterface", () => {
 
     it("should throw if approving token as its spender", async () => {
       try {
-        await tokenInterface.approve(owner, spender, spender, amount);
+        await tokenInterface.approve(ownerAddress, spenderAddress, spenderAddress, amount);
       } catch (error) {
         expect(error).toStrictEqual(new SdkError(`Cant approve token as its spender`));
         expect(Contract).not.toHaveBeenCalled();
@@ -643,14 +643,14 @@ describe("TokenInterface", () => {
 
   describe("allowance", () => {
     it("should return allowance when is a non native token", async () => {
-      const allowance = { owner, token, spender, amount };
+      const allowance = { owner: ownerAddress, token: tokenAddress, spender: spenderAddress, amount };
       allowanceMock.mockReturnValue(amount);
-      const allowanceResult = await tokenInterface.allowance(owner, token, spender);
+      const allowanceResult = await tokenInterface.allowance(ownerAddress, tokenAddress, spenderAddress);
 
       expect(allowanceResult).toEqual(allowance);
       expect(Contract).toHaveBeenCalledTimes(1);
       expect(Contract).toHaveBeenCalledWith(
-        token,
+        tokenAddress,
         [
           "function approve(address _spender, uint256 _value) public",
           "function allowance(address _owner, address _spender) public view returns (uint256)"
@@ -658,12 +658,17 @@ describe("TokenInterface", () => {
         "reader"
       );
       expect(allowanceMock).toHaveBeenCalledTimes(1);
-      expect(allowanceMock).toHaveBeenCalledWith(owner, spender);
+      expect(allowanceMock).toHaveBeenCalledWith(ownerAddress, spenderAddress);
     });
 
     it("should return max allowance when is a native token", async () => {
-      const allowance = { owner, token: ZeroAddress, spender, amount: MaxUint256.toString() };
-      const allowanceResult = await tokenInterface.allowance(owner, ZeroAddress, spender);
+      const allowance = {
+        owner: ownerAddress,
+        token: ZeroAddress,
+        spender: spenderAddress,
+        amount: MaxUint256.toString()
+      };
+      const allowanceResult = await tokenInterface.allowance(ownerAddress, ZeroAddress, spenderAddress);
 
       expect(allowanceResult).toEqual(allowance);
       expect(Contract).not.toBeCalled();

--- a/src/interfaces/token.ts
+++ b/src/interfaces/token.ts
@@ -228,8 +228,8 @@ export class TokenInterface<C extends ChainId> extends ServiceInterface<C> {
     amount: Integer,
     overrides?: CallOverrides
   ): Promise<TransactionResponse> {
-    if (isNativeToken(tokenAddress)) throw new SdkError(`Native tokens cant be approved`);
-    if (tokenAddress === spenderAddress) throw new SdkError(`Cant approve token as its spender`);
+    if (isNativeToken(tokenAddress)) throw new SdkError(`Native tokens cant be approved: ${tokenAddress}`);
+    if (tokenAddress === spenderAddress) throw new SdkError(`Cant approve token as its spender: ${tokenAddress}`);
 
     const signer = this.ctx.provider.write.getSigner(ownerAddress);
     const tokenContract = new Contract(tokenAddress, TokenAbi, signer);

--- a/src/interfaces/token.ts
+++ b/src/interfaces/token.ts
@@ -203,7 +203,7 @@ export class TokenInterface<C extends ChainId> extends ServiceInterface<C> {
       amount: MaxUint256.toString()
     };
 
-    if (isNativeToken(tokenAddress)) return allowance;
+    if (isNativeToken(tokenAddress) || tokenAddress === spenderAddress) return allowance;
 
     const tokenContract = new Contract(tokenAddress, TokenAbi, this.ctx.provider.read);
     const allowanceAmount = await tokenContract.allowance(ownerAddress, spenderAddress);
@@ -231,6 +231,7 @@ export class TokenInterface<C extends ChainId> extends ServiceInterface<C> {
     overrides?: CallOverrides
   ): Promise<TransactionResponse> {
     if (isNativeToken(tokenAddress)) throw new SdkError(`Native tokens cant be approved`);
+    if (tokenAddress === spenderAddress) throw new SdkError(`Cant approve token as its spender`);
 
     const signer = this.ctx.provider.write.getSigner(ownerAddress);
     const tokenContract = new Contract(tokenAddress, TokenAbi, signer);

--- a/src/interfaces/token.ts
+++ b/src/interfaces/token.ts
@@ -1,7 +1,6 @@
 import { MaxUint256 } from "@ethersproject/constants";
 import { CallOverrides, Contract } from "@ethersproject/contracts";
-import { TransactionRequest, TransactionResponse } from "@ethersproject/providers";
-import BigNumber from "bignumber.js";
+import { TransactionResponse } from "@ethersproject/providers";
 
 import { CachedFetcher } from "../cache";
 import { ChainId, Chains } from "../chain";
@@ -16,8 +15,7 @@ import {
   TokenAllowance,
   TokenMetadata,
   TypedMap,
-  Usdc,
-  Vault
+  Usdc
 } from "../types";
 import { Balance, Icon, IconMap, Token } from "../types";
 
@@ -259,40 +257,6 @@ export class TokenInterface<C extends ChainId> extends ServiceInterface<C> {
     };
 
     return zapperTokens.map(setIcon);
-  }
-
-  /**
-   * Approve vault to spend a vault token on zapOut
-   * @param vault
-   * @param token
-   * @param account
-   * @returns transaction
-   */
-  async approveZapOut(vault: Vault, token: Address, account: Address): Promise<TransactionResponse | boolean> {
-    const signer = this.ctx.provider.write.getSigner(account);
-    if (vault.token === token) {
-      const gasPrice = await this.yearn.services.zapper.gas();
-      const gasPriceFastGwei = new BigNumber(gasPrice.fast).times(new BigNumber(10 ** 9));
-
-      const sellToken = token;
-
-      const zapOutApprovalState = await this.yearn.services.zapper.zapOutApprovalState(account, sellToken);
-      if (!zapOutApprovalState.isApproved) {
-        const zapOutApprovalParams = await this.yearn.services.zapper.zapOutApprovalTransaction(
-          account,
-          sellToken,
-          gasPriceFastGwei.toString()
-        );
-        const transaction: TransactionRequest = {
-          to: zapOutApprovalParams.to,
-          from: zapOutApprovalParams.from,
-          gasPrice: zapOutApprovalParams.gasPrice,
-          data: zapOutApprovalParams.data as string
-        };
-        return signer.sendTransaction(transaction);
-      }
-    }
-    return false;
   }
 
   /**

--- a/src/interfaces/vault.spec.ts
+++ b/src/interfaces/vault.spec.ts
@@ -123,8 +123,8 @@ jest.mock("../yearn", () => ({
     },
     tokens: {
       metadata: tokensMetadataMock,
-      _allowance: tokenAllowanceMock,
-      _approve: tokenApproveMock
+      allowance: tokenAllowanceMock,
+      approve: tokenApproveMock
     }
   }))
 }));

--- a/src/interfaces/vault.spec.ts
+++ b/src/interfaces/vault.spec.ts
@@ -707,13 +707,13 @@ describe("VaultInterface", () => {
 
   describe("getDepositAllowance", () => {
     it("should fetch token deposit allowance", async () => {
-      const getDepositSpenderAddressMock = jest.fn().mockResolvedValue(spenderAddress);
-      (vaultInterface as any).getDepositSpenderAddress = getDepositSpenderAddressMock;
+      const getDepositContractAddressMock = jest.fn().mockResolvedValue(spenderAddress);
+      (vaultInterface as any).getDepositContractAddress = getDepositContractAddressMock;
 
       await vaultInterface.getDepositAllowance(accountAddress, vaultAddress, tokenAddress);
 
-      expect(getDepositSpenderAddressMock).toHaveBeenCalledTimes(1);
-      expect(getDepositSpenderAddressMock).toHaveBeenCalledWith(vaultAddress, tokenAddress);
+      expect(getDepositContractAddressMock).toHaveBeenCalledTimes(1);
+      expect(getDepositContractAddressMock).toHaveBeenCalledWith(vaultAddress, tokenAddress);
       expect(tokenAllowanceMock).toHaveBeenCalledTimes(1);
       expect(tokenAllowanceMock).toHaveBeenCalledWith(accountAddress, tokenAddress, spenderAddress);
     });
@@ -721,13 +721,13 @@ describe("VaultInterface", () => {
 
   describe("getWithdrawAllowance", () => {
     it("should fetch token withdraw allowance", async () => {
-      const getWithdrawSpenderAddressMock = jest.fn().mockResolvedValue(spenderAddress);
-      (vaultInterface as any).getWithdrawSpenderAddress = getWithdrawSpenderAddressMock;
+      const getWithdrawContractAddressMock = jest.fn().mockResolvedValue(spenderAddress);
+      (vaultInterface as any).getWithdrawContractAddress = getWithdrawContractAddressMock;
 
       await vaultInterface.getWithdrawAllowance(accountAddress, vaultAddress, tokenAddress);
 
-      expect(getWithdrawSpenderAddressMock).toHaveBeenCalledTimes(1);
-      expect(getWithdrawSpenderAddressMock).toHaveBeenCalledWith(vaultAddress, tokenAddress);
+      expect(getWithdrawContractAddressMock).toHaveBeenCalledTimes(1);
+      expect(getWithdrawContractAddressMock).toHaveBeenCalledWith(vaultAddress, tokenAddress);
       expect(tokenAllowanceMock).toHaveBeenCalledTimes(1);
       expect(tokenAllowanceMock).toHaveBeenCalledWith(accountAddress, vaultAddress, spenderAddress);
     });
@@ -736,13 +736,13 @@ describe("VaultInterface", () => {
   describe("approveDeposit", () => {
     describe("when no amount provided", () => {
       it("should infinite approve", async () => {
-        const getDepositSpenderAddressMock = jest.fn().mockResolvedValue(spenderAddress);
-        (vaultInterface as any).getDepositSpenderAddress = getDepositSpenderAddressMock;
+        const getDepositContractAddressMock = jest.fn().mockResolvedValue(spenderAddress);
+        (vaultInterface as any).getDepositContractAddress = getDepositContractAddressMock;
 
         await vaultInterface.approveDeposit(accountAddress, vaultAddress, tokenAddress);
 
-        expect(getDepositSpenderAddressMock).toHaveBeenCalledTimes(1);
-        expect(getDepositSpenderAddressMock).toHaveBeenCalledWith(vaultAddress, tokenAddress);
+        expect(getDepositContractAddressMock).toHaveBeenCalledTimes(1);
+        expect(getDepositContractAddressMock).toHaveBeenCalledWith(vaultAddress, tokenAddress);
         expect(tokenApproveMock).toHaveBeenCalledTimes(1);
         expect(tokenApproveMock).toHaveBeenCalledWith(
           accountAddress,
@@ -757,13 +757,13 @@ describe("VaultInterface", () => {
     describe("when amount provided", () => {
       it("should approve exact amount", async () => {
         const amount: Integer = "1000000";
-        const getDepositSpenderAddressMock = jest.fn().mockResolvedValue(spenderAddress);
-        (vaultInterface as any).getDepositSpenderAddress = getDepositSpenderAddressMock;
+        const getDepositContractAddressMock = jest.fn().mockResolvedValue(spenderAddress);
+        (vaultInterface as any).getDepositContractAddress = getDepositContractAddressMock;
 
         await vaultInterface.approveDeposit(accountAddress, vaultAddress, tokenAddress, amount);
 
-        expect(getDepositSpenderAddressMock).toHaveBeenCalledTimes(1);
-        expect(getDepositSpenderAddressMock).toHaveBeenCalledWith(vaultAddress, tokenAddress);
+        expect(getDepositContractAddressMock).toHaveBeenCalledTimes(1);
+        expect(getDepositContractAddressMock).toHaveBeenCalledWith(vaultAddress, tokenAddress);
         expect(tokenApproveMock).toHaveBeenCalledTimes(1);
         expect(tokenApproveMock).toHaveBeenCalledWith(accountAddress, tokenAddress, spenderAddress, amount, undefined);
       });
@@ -773,13 +773,13 @@ describe("VaultInterface", () => {
   describe("withdrawDeposit", () => {
     describe("when no amount provided", () => {
       it("should infinite approve", async () => {
-        const getWithdrawSpenderAddressMock = jest.fn().mockResolvedValue(spenderAddress);
-        (vaultInterface as any).getWithdrawSpenderAddress = getWithdrawSpenderAddressMock;
+        const getWithdrawContractAddressMock = jest.fn().mockResolvedValue(spenderAddress);
+        (vaultInterface as any).getWithdrawContractAddress = getWithdrawContractAddressMock;
 
         await vaultInterface.approveWithdraw(accountAddress, vaultAddress, tokenAddress);
 
-        expect(getWithdrawSpenderAddressMock).toHaveBeenCalledTimes(1);
-        expect(getWithdrawSpenderAddressMock).toHaveBeenCalledWith(vaultAddress, tokenAddress);
+        expect(getWithdrawContractAddressMock).toHaveBeenCalledTimes(1);
+        expect(getWithdrawContractAddressMock).toHaveBeenCalledWith(vaultAddress, tokenAddress);
         expect(tokenApproveMock).toHaveBeenCalledTimes(1);
         expect(tokenApproveMock).toHaveBeenCalledWith(
           accountAddress,
@@ -794,13 +794,13 @@ describe("VaultInterface", () => {
     describe("when amount provided", () => {
       it("should approve exact amount", async () => {
         const amount: Integer = "1000000";
-        const getWithdrawSpenderAddressMock = jest.fn().mockResolvedValue(spenderAddress);
-        (vaultInterface as any).getWithdrawSpenderAddress = getWithdrawSpenderAddressMock;
+        const getWithdrawContractAddressMock = jest.fn().mockResolvedValue(spenderAddress);
+        (vaultInterface as any).getWithdrawContractAddress = getWithdrawContractAddressMock;
 
         await vaultInterface.approveWithdraw(accountAddress, vaultAddress, tokenAddress, amount);
 
-        expect(getWithdrawSpenderAddressMock).toHaveBeenCalledTimes(1);
-        expect(getWithdrawSpenderAddressMock).toHaveBeenCalledWith(vaultAddress, tokenAddress);
+        expect(getWithdrawContractAddressMock).toHaveBeenCalledTimes(1);
+        expect(getWithdrawContractAddressMock).toHaveBeenCalledWith(vaultAddress, tokenAddress);
         expect(tokenApproveMock).toHaveBeenCalledTimes(1);
         expect(tokenApproveMock).toHaveBeenCalledWith(accountAddress, vaultAddress, spenderAddress, amount, undefined);
       });

--- a/src/interfaces/vault.spec.ts
+++ b/src/interfaces/vault.spec.ts
@@ -157,10 +157,10 @@ jest.mock("@ethersproject/contracts", () => ({
 }));
 
 describe("VaultInterface", () => {
-  const account: Address = "0xAccount";
-  const vault: Address = "0xVault";
-  const token: Address = "0xToken";
-  const spender: Address = "0xSpender";
+  const accountAddress: Address = "0xAccount";
+  const vaultAddress: Address = "0xVault";
+  const tokenAddress: Address = "0xToken";
+  const spenderAddress: Address = "0xSpender";
   let vaultInterface: VaultInterface<1>;
   let mockedYearn: Yearn<ChainId>;
 
@@ -707,59 +707,65 @@ describe("VaultInterface", () => {
 
   describe("getDepositAllowance", () => {
     it("should fetch token deposit allowance", async () => {
-      const getDepositSpenderAddressMock = jest.fn().mockResolvedValue(spender);
+      const getDepositSpenderAddressMock = jest.fn().mockResolvedValue(spenderAddress);
       (vaultInterface as any).getDepositSpenderAddress = getDepositSpenderAddressMock;
 
-      await vaultInterface.getDepositAllowance(account, vault, token);
+      await vaultInterface.getDepositAllowance(accountAddress, vaultAddress, tokenAddress);
 
       expect(getDepositSpenderAddressMock).toHaveBeenCalledTimes(1);
-      expect(getDepositSpenderAddressMock).toHaveBeenCalledWith(vault, token);
+      expect(getDepositSpenderAddressMock).toHaveBeenCalledWith(vaultAddress, tokenAddress);
       expect(tokenAllowanceMock).toHaveBeenCalledTimes(1);
-      expect(tokenAllowanceMock).toHaveBeenCalledWith(account, token, spender);
+      expect(tokenAllowanceMock).toHaveBeenCalledWith(accountAddress, tokenAddress, spenderAddress);
     });
   });
 
   describe("getWithdrawAllowance", () => {
     it("should fetch token withdraw allowance", async () => {
-      const getWithdrawSpenderAddressMock = jest.fn().mockResolvedValue(spender);
+      const getWithdrawSpenderAddressMock = jest.fn().mockResolvedValue(spenderAddress);
       (vaultInterface as any).getWithdrawSpenderAddress = getWithdrawSpenderAddressMock;
 
-      await vaultInterface.getWithdrawAllowance(account, vault, token);
+      await vaultInterface.getWithdrawAllowance(accountAddress, vaultAddress, tokenAddress);
 
       expect(getWithdrawSpenderAddressMock).toHaveBeenCalledTimes(1);
-      expect(getWithdrawSpenderAddressMock).toHaveBeenCalledWith(vault, token);
+      expect(getWithdrawSpenderAddressMock).toHaveBeenCalledWith(vaultAddress, tokenAddress);
       expect(tokenAllowanceMock).toHaveBeenCalledTimes(1);
-      expect(tokenAllowanceMock).toHaveBeenCalledWith(account, vault, spender);
+      expect(tokenAllowanceMock).toHaveBeenCalledWith(accountAddress, vaultAddress, spenderAddress);
     });
   });
 
   describe("approveDeposit", () => {
     describe("when no amount provided", () => {
       it("should infinite approve", async () => {
-        const getDepositSpenderAddressMock = jest.fn().mockResolvedValue(spender);
+        const getDepositSpenderAddressMock = jest.fn().mockResolvedValue(spenderAddress);
         (vaultInterface as any).getDepositSpenderAddress = getDepositSpenderAddressMock;
 
-        await vaultInterface.approveDeposit(account, vault, token);
+        await vaultInterface.approveDeposit(accountAddress, vaultAddress, tokenAddress);
 
         expect(getDepositSpenderAddressMock).toHaveBeenCalledTimes(1);
-        expect(getDepositSpenderAddressMock).toHaveBeenCalledWith(vault, token);
+        expect(getDepositSpenderAddressMock).toHaveBeenCalledWith(vaultAddress, tokenAddress);
         expect(tokenApproveMock).toHaveBeenCalledTimes(1);
-        expect(tokenApproveMock).toHaveBeenCalledWith(account, token, spender, MaxUint256.toString(), undefined);
+        expect(tokenApproveMock).toHaveBeenCalledWith(
+          accountAddress,
+          tokenAddress,
+          spenderAddress,
+          MaxUint256.toString(),
+          undefined
+        );
       });
     });
 
     describe("when amount provided", () => {
       it("should approve exact amount", async () => {
         const amount: Integer = "1000000";
-        const getDepositSpenderAddressMock = jest.fn().mockResolvedValue(spender);
+        const getDepositSpenderAddressMock = jest.fn().mockResolvedValue(spenderAddress);
         (vaultInterface as any).getDepositSpenderAddress = getDepositSpenderAddressMock;
 
-        await vaultInterface.approveDeposit(account, vault, token, amount);
+        await vaultInterface.approveDeposit(accountAddress, vaultAddress, tokenAddress, amount);
 
         expect(getDepositSpenderAddressMock).toHaveBeenCalledTimes(1);
-        expect(getDepositSpenderAddressMock).toHaveBeenCalledWith(vault, token);
+        expect(getDepositSpenderAddressMock).toHaveBeenCalledWith(vaultAddress, tokenAddress);
         expect(tokenApproveMock).toHaveBeenCalledTimes(1);
-        expect(tokenApproveMock).toHaveBeenCalledWith(account, token, spender, amount, undefined);
+        expect(tokenApproveMock).toHaveBeenCalledWith(accountAddress, tokenAddress, spenderAddress, amount, undefined);
       });
     });
   });
@@ -767,30 +773,36 @@ describe("VaultInterface", () => {
   describe("withdrawDeposit", () => {
     describe("when no amount provided", () => {
       it("should infinite approve", async () => {
-        const getWithdrawSpenderAddressMock = jest.fn().mockResolvedValue(spender);
+        const getWithdrawSpenderAddressMock = jest.fn().mockResolvedValue(spenderAddress);
         (vaultInterface as any).getWithdrawSpenderAddress = getWithdrawSpenderAddressMock;
 
-        await vaultInterface.approveWithdraw(account, vault, token);
+        await vaultInterface.approveWithdraw(accountAddress, vaultAddress, tokenAddress);
 
         expect(getWithdrawSpenderAddressMock).toHaveBeenCalledTimes(1);
-        expect(getWithdrawSpenderAddressMock).toHaveBeenCalledWith(vault, token);
+        expect(getWithdrawSpenderAddressMock).toHaveBeenCalledWith(vaultAddress, tokenAddress);
         expect(tokenApproveMock).toHaveBeenCalledTimes(1);
-        expect(tokenApproveMock).toHaveBeenCalledWith(account, vault, spender, MaxUint256.toString(), undefined);
+        expect(tokenApproveMock).toHaveBeenCalledWith(
+          accountAddress,
+          vaultAddress,
+          spenderAddress,
+          MaxUint256.toString(),
+          undefined
+        );
       });
     });
 
     describe("when amount provided", () => {
       it("should approve exact amount", async () => {
         const amount: Integer = "1000000";
-        const getWithdrawSpenderAddressMock = jest.fn().mockResolvedValue(spender);
+        const getWithdrawSpenderAddressMock = jest.fn().mockResolvedValue(spenderAddress);
         (vaultInterface as any).getWithdrawSpenderAddress = getWithdrawSpenderAddressMock;
 
-        await vaultInterface.approveWithdraw(account, vault, token, amount);
+        await vaultInterface.approveWithdraw(accountAddress, vaultAddress, tokenAddress, amount);
 
         expect(getWithdrawSpenderAddressMock).toHaveBeenCalledTimes(1);
-        expect(getWithdrawSpenderAddressMock).toHaveBeenCalledWith(vault, token);
+        expect(getWithdrawSpenderAddressMock).toHaveBeenCalledWith(vaultAddress, tokenAddress);
         expect(tokenApproveMock).toHaveBeenCalledTimes(1);
-        expect(tokenApproveMock).toHaveBeenCalledWith(account, vault, spender, amount, undefined);
+        expect(tokenApproveMock).toHaveBeenCalledWith(accountAddress, vaultAddress, spenderAddress, amount, undefined);
       });
     });
   });

--- a/src/interfaces/vault.spec.ts
+++ b/src/interfaces/vault.spec.ts
@@ -157,8 +157,11 @@ jest.mock("@ethersproject/contracts", () => ({
 }));
 
 describe("VaultInterface", () => {
+  const account: Address = "0xAccount";
+  const vault: Address = "0xVault";
+  const token: Address = "0xToken";
+  const spender: Address = "0xSpender";
   let vaultInterface: VaultInterface<1>;
-
   let mockedYearn: Yearn<ChainId>;
 
   beforeEach(() => {
@@ -704,10 +707,6 @@ describe("VaultInterface", () => {
 
   describe("getDepositAllowance", () => {
     it("should fetch token deposit allowance", async () => {
-      const account: Address = "0xAccount";
-      const vault: Address = "0xVault";
-      const token: Address = "0xToken";
-      const spender: Address = "0xSpender";
       const getDepositSpenderAddressMock = jest.fn().mockResolvedValue(spender);
       (vaultInterface as any).getDepositSpenderAddress = getDepositSpenderAddressMock;
 
@@ -722,10 +721,6 @@ describe("VaultInterface", () => {
 
   describe("getWithdrawAllowance", () => {
     it("should fetch token withdraw allowance", async () => {
-      const account: Address = "0xAccount";
-      const vault: Address = "0xVault";
-      const token: Address = "0xToken";
-      const spender: Address = "0xSpender";
       const getWithdrawSpenderAddressMock = jest.fn().mockResolvedValue(spender);
       (vaultInterface as any).getWithdrawSpenderAddress = getWithdrawSpenderAddressMock;
 
@@ -739,11 +734,6 @@ describe("VaultInterface", () => {
   });
 
   describe("approveDeposit", () => {
-    const account: Address = "0xAccount";
-    const vault: Address = "0xVault";
-    const token: Address = "0xToken";
-    const spender: Address = "0xSpender";
-
     describe("when no amount provided", () => {
       it("should infinite approve", async () => {
         const getDepositSpenderAddressMock = jest.fn().mockResolvedValue(spender);
@@ -775,11 +765,6 @@ describe("VaultInterface", () => {
   });
 
   describe("withdrawDeposit", () => {
-    const account: Address = "0xAccount";
-    const vault: Address = "0xVault";
-    const token: Address = "0xToken";
-    const spender: Address = "0xSpender";
-
     describe("when no amount provided", () => {
       it("should infinite approve", async () => {
         const getWithdrawSpenderAddressMock = jest.fn().mockResolvedValue(spender);

--- a/src/interfaces/vault.spec.ts
+++ b/src/interfaces/vault.spec.ts
@@ -703,7 +703,7 @@ describe("VaultInterface", () => {
   });
 
   describe("getDepositAllowance", () => {
-    it("should fetch token allowance", async () => {
+    it("should fetch token deposit allowance", async () => {
       const account: Address = "0xAccount";
       const vault: Address = "0xVault";
       const token: Address = "0xToken";
@@ -717,6 +717,24 @@ describe("VaultInterface", () => {
       expect(getDepositSpenderAddressMock).toHaveBeenCalledWith(vault, token);
       expect(tokenAllowanceMock).toHaveBeenCalledTimes(1);
       expect(tokenAllowanceMock).toHaveBeenCalledWith(account, token, spender);
+    });
+  });
+
+  describe("getWithdrawAllowance", () => {
+    it("should fetch token withdraw allowance", async () => {
+      const account: Address = "0xAccount";
+      const vault: Address = "0xVault";
+      const token: Address = "0xToken";
+      const spender: Address = "0xSpender";
+      const getWithdrawSpenderAddressMock = jest.fn().mockResolvedValue(spender);
+      (vaultInterface as any).getWithdrawSpenderAddress = getWithdrawSpenderAddressMock;
+
+      await vaultInterface.getWithdrawAllowance(account, vault, token);
+
+      expect(getWithdrawSpenderAddressMock).toHaveBeenCalledTimes(1);
+      expect(getWithdrawSpenderAddressMock).toHaveBeenCalledWith(vault, token);
+      expect(tokenAllowanceMock).toHaveBeenCalledTimes(1);
+      expect(tokenAllowanceMock).toHaveBeenCalledWith(account, vault, spender);
     });
   });
 
@@ -752,6 +770,42 @@ describe("VaultInterface", () => {
         expect(getDepositSpenderAddressMock).toHaveBeenCalledWith(vault, token);
         expect(tokenApproveMock).toHaveBeenCalledTimes(1);
         expect(tokenApproveMock).toHaveBeenCalledWith(account, token, spender, amount, undefined);
+      });
+    });
+  });
+
+  describe("withdrawDeposit", () => {
+    const account: Address = "0xAccount";
+    const vault: Address = "0xVault";
+    const token: Address = "0xToken";
+    const spender: Address = "0xSpender";
+
+    describe("when no amount provided", () => {
+      it("should infinite approve", async () => {
+        const getWithdrawSpenderAddressMock = jest.fn().mockResolvedValue(spender);
+        (vaultInterface as any).getWithdrawSpenderAddress = getWithdrawSpenderAddressMock;
+
+        await vaultInterface.approveWithdraw(account, vault, token);
+
+        expect(getWithdrawSpenderAddressMock).toHaveBeenCalledTimes(1);
+        expect(getWithdrawSpenderAddressMock).toHaveBeenCalledWith(vault, token);
+        expect(tokenApproveMock).toHaveBeenCalledTimes(1);
+        expect(tokenApproveMock).toHaveBeenCalledWith(account, vault, spender, MaxUint256.toString(), undefined);
+      });
+    });
+
+    describe("when amount provided", () => {
+      it("should approve exact amount", async () => {
+        const amount: Integer = "1000000";
+        const getWithdrawSpenderAddressMock = jest.fn().mockResolvedValue(spender);
+        (vaultInterface as any).getWithdrawSpenderAddress = getWithdrawSpenderAddressMock;
+
+        await vaultInterface.approveWithdraw(account, vault, token, amount);
+
+        expect(getWithdrawSpenderAddressMock).toHaveBeenCalledTimes(1);
+        expect(getWithdrawSpenderAddressMock).toHaveBeenCalledWith(vault, token);
+        expect(tokenApproveMock).toHaveBeenCalledTimes(1);
+        expect(tokenApproveMock).toHaveBeenCalledWith(account, vault, spender, amount, undefined);
       });
     });
   });

--- a/src/interfaces/vault.ts
+++ b/src/interfaces/vault.ts
@@ -318,7 +318,7 @@ export class VaultInterface<T extends ChainId> extends ServiceInterface<T> {
     vaultAddress: Address,
     tokenAddress: Address
   ): Promise<TokenAllowance> {
-    const spenderAddress = await this.getDepositSpenderAddress(vaultAddress, tokenAddress);
+    const spenderAddress = await this.getDepositContractAddress(vaultAddress, tokenAddress);
     return this.yearn.tokens.allowance(accountAddress, tokenAddress, spenderAddress);
   }
 
@@ -334,7 +334,7 @@ export class VaultInterface<T extends ChainId> extends ServiceInterface<T> {
     vaultAddress: Address,
     tokenAddress: Address
   ): Promise<TokenAllowance> {
-    const spenderAddress = await this.getWithdrawSpenderAddress(vaultAddress, tokenAddress);
+    const spenderAddress = await this.getWithdrawContractAddress(vaultAddress, tokenAddress);
     return this.yearn.tokens.allowance(accountAddress, vaultAddress, spenderAddress);
   }
 
@@ -354,7 +354,7 @@ export class VaultInterface<T extends ChainId> extends ServiceInterface<T> {
     amount?: Integer,
     overrides?: CallOverrides
   ): Promise<TransactionResponse> {
-    const spenderAddress = await this.getDepositSpenderAddress(vaultAddress, tokenAddress);
+    const spenderAddress = await this.getDepositContractAddress(vaultAddress, tokenAddress);
     return this.yearn.tokens.approve(
       accountAddress,
       tokenAddress,
@@ -380,7 +380,7 @@ export class VaultInterface<T extends ChainId> extends ServiceInterface<T> {
     amount?: Integer,
     overrides?: CallOverrides
   ): Promise<TransactionResponse> {
-    const spenderAddress = await this.getWithdrawSpenderAddress(vaultAddress, tokenAddress);
+    const spenderAddress = await this.getWithdrawContractAddress(vaultAddress, tokenAddress);
     return this.yearn.tokens.approve(
       accountAddress,
       vaultAddress,
@@ -390,7 +390,7 @@ export class VaultInterface<T extends ChainId> extends ServiceInterface<T> {
     );
   }
 
-  private async getDepositSpenderAddress(vaultAddress: Address, tokenAddress: Address): Promise<Address> {
+  private async getDepositContractAddress(vaultAddress: Address, tokenAddress: Address): Promise<Address> {
     if (isNativeToken(tokenAddress)) return vaultAddress;
 
     const willDepositUnderlyingToken = await this.isUnderlyingToken(vaultAddress, tokenAddress);
@@ -412,7 +412,7 @@ export class VaultInterface<T extends ChainId> extends ServiceInterface<T> {
     return zapContractAddress;
   }
 
-  private async getWithdrawSpenderAddress(vaultAddress: Address, tokenAddress: Address): Promise<Address> {
+  private async getWithdrawContractAddress(vaultAddress: Address, tokenAddress: Address): Promise<Address> {
     const willWithdrawToUnderlyingToken = await this.isUnderlyingToken(vaultAddress, tokenAddress);
     if (willWithdrawToUnderlyingToken) return vaultAddress;
 

--- a/src/interfaces/vault.ts
+++ b/src/interfaces/vault.ts
@@ -402,7 +402,7 @@ export class VaultInterface<T extends ChainId> extends ServiceInterface<T> {
       return partnerTrackingContractAddress;
     }
 
-    if (willDepositUnderlyingToken && !shouldUsePartnerService) {
+    if (willDepositUnderlyingToken) {
       return vaultAddress;
     }
 

--- a/src/interfaces/vault.ts
+++ b/src/interfaces/vault.ts
@@ -5,7 +5,7 @@ import { TransactionRequest, TransactionResponse } from "@ethersproject/provider
 
 import { CachedFetcher } from "../cache";
 import { ChainId } from "../chain";
-import { ServiceInterface } from "../common";
+import { ContractAddressId, ServiceInterface } from "../common";
 import { chunkArray, EthAddress, WethAddress } from "../helpers";
 import { PickleJars } from "../services/partners/pickle";
 import {
@@ -363,11 +363,9 @@ export class VaultInterface<T extends ChainId> extends ServiceInterface<T> {
     }
 
     const willZapToPickleJar = PickleJars.includes(vaultAddress);
-    const zapProtocol = willZapToPickleJar ? ZapProtocol.PICKLE : ZapProtocol.YEARN;
-    console.log(zapProtocol);
-    // TODO: Waiting for correct endpoint from zapper to get latest zapIn contract address
-    // const zapInApprovalState = await this.yearn.services.zapper.zapInApprovalState(account, token, zapProtocol);
-    return "0xZapInContract";
+    const zapContract = willZapToPickleJar ? ContractAddressId.pickleZapIn : ContractAddressId.zapperZapIn;
+    const zapContractAddress = await this.yearn.addressProvider.addressById(zapContract);
+    return zapContractAddress;
   }
 
   private async isUnderlyingToken(vaultAddress: Address, tokenAddress: Address): Promise<boolean> {

--- a/src/interfaces/vault.ts
+++ b/src/interfaces/vault.ts
@@ -1,4 +1,5 @@
 import { BigNumber } from "@ethersproject/bignumber";
+import { MaxUint256 } from "@ethersproject/constants";
 import { CallOverrides, Contract } from "@ethersproject/contracts";
 import { TransactionRequest, TransactionResponse } from "@ethersproject/providers";
 
@@ -15,6 +16,7 @@ import {
   Integer,
   SdkError,
   Token,
+  TokenAllowance,
   TokenMetadata,
   VaultDynamic,
   VaultMetadataOverrides,
@@ -302,6 +304,75 @@ export class VaultInterface<T extends ChainId> extends ServiceInterface<T> {
         );
       })
     ).then(arr => arr.flat());
+  }
+
+  /**
+   * Fetch the token amount that has been allowed to be used for deposits
+   * @param accountAddress
+   * @param vaultAddress
+   * @param tokenAddress
+   * @returns TokenAllowance
+   */
+  async getDepositAllowance(
+    accountAddress: Address,
+    vaultAddress: Address,
+    tokenAddress: Address
+  ): Promise<TokenAllowance> {
+    const spenderAddress = await this.getDepositSpenderAddress(vaultAddress, tokenAddress);
+    return this.yearn.tokens._allowance(accountAddress, tokenAddress, spenderAddress);
+  }
+
+  /**
+   * Approve the token amount to allow to be used for deposits
+   * @param accountAddress
+   * @param vaultAddress
+   * @param tokenAddress
+   * @param amount
+   * @param overrides
+   * @returns TransactionResponse
+   */
+  async approveDeposit(
+    accountAddress: Address,
+    vaultAddress: Address,
+    tokenAddress: Address,
+    amount?: Integer,
+    overrides?: CallOverrides
+  ): Promise<TransactionResponse> {
+    const spenderAddress = await this.getDepositSpenderAddress(vaultAddress, tokenAddress);
+    return this.yearn.tokens._approve(
+      accountAddress,
+      tokenAddress,
+      spenderAddress,
+      amount ?? MaxUint256.toString(),
+      overrides
+    );
+  }
+
+  private async getDepositSpenderAddress(vaultAddress: Address, tokenAddress: Address): Promise<Address> {
+    const willDepositUnderlyingToken = await this.isUnderlyingToken(vaultAddress, tokenAddress);
+    const shouldUsePartnerService = this.shouldUsePartnerService(vaultAddress);
+
+    if (willDepositUnderlyingToken && shouldUsePartnerService) {
+      const partnerTrackingContractAddress = await this.yearn.services.partner?.address;
+      if (!partnerTrackingContractAddress) throw new SdkError("Partner Tracking Contract Address not defined");
+      return partnerTrackingContractAddress;
+    }
+
+    if (willDepositUnderlyingToken && !shouldUsePartnerService) {
+      return vaultAddress;
+    }
+
+    const willZapToPickleJar = PickleJars.includes(vaultAddress);
+    const zapProtocol = willZapToPickleJar ? ZapProtocol.PICKLE : ZapProtocol.YEARN;
+    console.log(zapProtocol);
+    // TODO: Waiting for correct endpoint from zapper to get latest zapIn contract address
+    // const zapInApprovalState = await this.yearn.services.zapper.zapInApprovalState(account, token, zapProtocol);
+    return "0xZapInContract";
+  }
+
+  private async isUnderlyingToken(vaultAddress: Address, tokenAddress: Address): Promise<boolean> {
+    const [vault] = await this.getStatic([vaultAddress]);
+    return vault.token === tokenAddress;
   }
 
   /**

--- a/src/interfaces/vault.ts
+++ b/src/interfaces/vault.ts
@@ -319,7 +319,7 @@ export class VaultInterface<T extends ChainId> extends ServiceInterface<T> {
     tokenAddress: Address
   ): Promise<TokenAllowance> {
     const spenderAddress = await this.getDepositSpenderAddress(vaultAddress, tokenAddress);
-    return this.yearn.tokens._allowance(accountAddress, tokenAddress, spenderAddress);
+    return this.yearn.tokens.allowance(accountAddress, tokenAddress, spenderAddress);
   }
 
   /**
@@ -339,7 +339,7 @@ export class VaultInterface<T extends ChainId> extends ServiceInterface<T> {
     overrides?: CallOverrides
   ): Promise<TransactionResponse> {
     const spenderAddress = await this.getDepositSpenderAddress(vaultAddress, tokenAddress);
-    return this.yearn.tokens._approve(
+    return this.yearn.tokens.approve(
       accountAddress,
       tokenAddress,
       spenderAddress,

--- a/src/interfaces/vault.ts
+++ b/src/interfaces/vault.ts
@@ -407,8 +407,8 @@ export class VaultInterface<T extends ChainId> extends ServiceInterface<T> {
     }
 
     const willZapToPickleJar = PickleJars.includes(vaultAddress);
-    const zapContract = willZapToPickleJar ? ContractAddressId.pickleZapIn : ContractAddressId.zapperZapIn;
-    const zapContractAddress = await this.yearn.addressProvider.addressById(zapContract);
+    const zapContractId = willZapToPickleJar ? ContractAddressId.pickleZapIn : ContractAddressId.zapperZapIn;
+    const zapContractAddress = await this.yearn.addressProvider.addressById(zapContractId);
     return zapContractAddress;
   }
 

--- a/src/yearn.ts
+++ b/src/yearn.ts
@@ -88,7 +88,7 @@ export class Yearn<T extends ChainId> {
    * ```
    */
   ready: Promise<void[]>;
-  private addressProvider: AddressProvider<T>;
+  addressProvider: AddressProvider<T>;
 
   /**
    * Create a new SDK instance.


### PR DESCRIPTION
## Description

- Remove from the token interface all vault related functionality.
- Add to vault interface the corresponding use cases for fetching deposit allowance and approving tokens for deposit.
- Add to vault interface the corresponding use cases for fetching withdraw allowance and approving tokens for withdraw.

## Motivation and Context

Currently tokens interface has use cases that correspond to vault interface.

## How Has This Been Tested?

`src/interfaces/token.spec.ts`
`src/interfaces/vault.spec.ts`
