### PR TITLE
feat: Add `BigNumber` parsers

### DIFF
--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -41,10 +41,10 @@ export type Integer = string;
 export type Usdc = string;
 
 /**
- * Utility type to help distinguish [[Integer]]s that represent a Wei (18 dec)
- * value.
+ * Utility type to help distinguish [[Integer]]s that represents an already
+ * normalized value with the corresponding decimals from their Integer form.
  */
-export type Wei = string;
+export type Unit = string;
 
 /**
  * Utility type to describe a map of predefined keys with the same value.

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -41,6 +41,12 @@ export type Integer = string;
 export type Usdc = string;
 
 /**
+ * Utility type to help distinguish [[Integer]]s that represent a Wei (18 dec)
+ * value.
+ */
+export type Wei = string;
+
+/**
  * Utility type to describe a map of predefined keys with the same value.
  */
 export type TypedMap<K extends string | number | symbol, V> = { [key in K]: V };

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,0 +1,1 @@
+export * from "./parser";

--- a/src/utils/parser.spec.ts
+++ b/src/utils/parser.spec.ts
@@ -1,0 +1,62 @@
+import BigNumber from "bignumber.js";
+
+import { toBN, toUnit, toWei } from "./parser";
+
+describe("Parsers", () => {
+  describe("toBN", () => {
+    it("should convert `string` to `BigNumber`", () => {
+      const actual = toBN("123");
+
+      expect(actual).toEqual(new BigNumber(123));
+      expect(actual instanceof BigNumber).toBeTruthy();
+    });
+
+    it("should convert `number` to `BigNumber`", () => {
+      const actual = toBN(123);
+
+      expect(actual).toEqual(new BigNumber(123));
+      expect(actual instanceof BigNumber).toBeTruthy();
+    });
+
+    it.each`
+      falsyArgument
+      ${false}
+      ${0}
+      ${""}
+      ${null}
+      ${undefined}
+      ${NaN}
+    `(`should return \`BigNumber(0)\` when given "$falsyArgument"`, ({ falsyArgument }) => {
+      const actual = toBN(falsyArgument);
+
+      expect(actual).toEqual(new BigNumber(0));
+      expect(actual instanceof BigNumber).toBeTruthy();
+    });
+
+    it("should return `BigNumber(0)` when given a falsy argument", () => {
+      const actualWithEmptyString = toBN("");
+      const actualWithUndefined = toBN();
+
+      expect(actualWithEmptyString).toEqual(new BigNumber(0));
+      expect(actualWithEmptyString instanceof BigNumber).toBeTruthy();
+      expect(actualWithUndefined).toEqual(new BigNumber(0));
+      expect(actualWithUndefined instanceof BigNumber).toBeTruthy();
+    });
+  });
+
+  describe("toWei", () => {
+    it("should convert amount in Unit to Wei", () => {
+      const actual = toWei({ amount: "123", decimals: 18 });
+
+      expect(actual).toEqual("123000000000000000000");
+    });
+  });
+
+  describe("toUnit", () => {
+    it("should convert amount in Wei to Unit", () => {
+      const actual = toUnit({ amount: "123000000000000000000", decimals: 18 });
+
+      expect(actual).toEqual("123");
+    });
+  });
+});

--- a/src/utils/parser.ts
+++ b/src/utils/parser.ts
@@ -1,0 +1,21 @@
+import BigNumber from "bignumber.js";
+
+import { Integer, Wei } from "../types";
+
+export const toBN = (amount?: Integer | number): BigNumber => {
+  return new BigNumber(amount || "0");
+};
+
+export const toWei = ({ amount, decimals }: { amount: Integer; decimals: number }): Wei => {
+  const ONE_UNIT = toBN(10).pow(decimals);
+  return toBN(amount)
+    .times(ONE_UNIT)
+    .toFixed(0);
+};
+
+export const toUnit = ({ amount, decimals }: { amount: Wei; decimals: number }): Integer => {
+  const ONE_UNIT = toBN(10).pow(decimals);
+  return toBN(amount)
+    .div(ONE_UNIT)
+    .toString();
+};

--- a/src/utils/parser.ts
+++ b/src/utils/parser.ts
@@ -1,19 +1,19 @@
 import BigNumber from "bignumber.js";
 
-import { Integer, Wei } from "../types";
+import { Integer, Unit } from "../types";
 
 export const toBN = (amount?: Integer | number): BigNumber => {
   return new BigNumber(amount || "0");
 };
 
-export const toWei = ({ amount, decimals }: { amount: Integer; decimals: number }): Wei => {
+export const toWei = ({ amount, decimals }: { amount: Unit; decimals: number }): Integer => {
   const ONE_UNIT = toBN(10).pow(decimals);
   return toBN(amount)
     .times(ONE_UNIT)
     .toFixed(0);
 };
 
-export const toUnit = ({ amount, decimals }: { amount: Wei; decimals: number }): Integer => {
+export const toUnit = ({ amount, decimals }: { amount: Integer; decimals: number }): Unit => {
   const ONE_UNIT = toBN(10).pow(decimals);
   return toBN(amount)
     .div(ONE_UNIT)


### PR DESCRIPTION
## Description

Add some utility functions to work with `BigNumber`

* `toBN()`
* `toWei()`
* `toUnit()`

If everyone happy with using these, happy to refactor the whole codebase to use these instead in this PR.

## Motivation and Context

In the frontend we have [formatters](https://github.com/yearn/yearn-finance-v3/blob/develop/src/utils/format.ts) to help working with `BigNumber`, for consistency we could have these in the SDK as well

## How Has This Been Tested?

`src/utils/parser.spec.ts`
