### PR TITLE
fix: make all subgraph endpoints configurable

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -47,8 +47,10 @@ export interface CacheConfiguration {
 }
 
 export interface SubgraphConfiguration {
-  subgraphKey: string;
-  mainnetSubgraphId: string;
+  subgraphKey?: string;
+  mainnetSubgraphId?: string;
+  fantomSubgraphEndpoint?: string;
+  arbitrumSubgraphEndpoint?: string;
 }
 
 /**
@@ -146,9 +148,8 @@ export class Context implements ContextValue {
     throw new SdkError("cache must be defined in Context for this feature to work.");
   }
 
-  get subgraph(): SubgraphConfiguration {
-    if (this.ctx.subgraph) return this.ctx.subgraph;
-    throw new SdkError("subgraph configuration must be defined in Context for this feature to work.");
+  get subgraph(): SubgraphConfiguration | undefined {
+    return this.ctx.subgraph;
   }
 
   get partnerId(): string | undefined {

--- a/src/context.ts
+++ b/src/context.ts
@@ -47,8 +47,7 @@ export interface CacheConfiguration {
 }
 
 export interface SubgraphConfiguration {
-  subgraphKey?: string;
-  mainnetSubgraphId?: string;
+  mainnetSubgraphEndpoint?: string;
   fantomSubgraphEndpoint?: string;
   arbitrumSubgraphEndpoint?: string;
 }

--- a/src/services/subgraph/index.ts
+++ b/src/services/subgraph/index.ts
@@ -12,9 +12,8 @@ export class SubgraphService extends Service {
     switch (chainId) {
       case 1:
       case 1337:
-        if (ctx.subgraph?.subgraphKey && ctx.subgraph.mainnetSubgraphId) {
-          this.yearnSubgraphEndpoint = `https://gateway.thegraph.com/api/${ctx.subgraph.subgraphKey}/subgraphs/id/${ctx.subgraph.mainnetSubgraphId}`;
-        }
+        // no fallback for mainnet as the hosted version has been deprecated.
+        this.yearnSubgraphEndpoint = ctx.subgraph?.mainnetSubgraphEndpoint;
         break;
       case 250:
         this.yearnSubgraphEndpoint =

--- a/src/services/subgraph/index.ts
+++ b/src/services/subgraph/index.ts
@@ -12,20 +12,19 @@ export class SubgraphService extends Service {
     switch (chainId) {
       case 1:
       case 1337:
-        try {
-          const subgraphConfig = ctx.subgraph;
-          this.yearnSubgraphEndpoint = `https://gateway.thegraph.com/api/${subgraphConfig.subgraphKey}/subgraphs/id/${subgraphConfig.mainnetSubgraphId}`;
-        } catch {
-          console.warn(
-            "no key has been provided for the mainnet subgraph - some data might be missing e.g. for earnings"
-          );
+        if (ctx.subgraph?.subgraphKey && ctx.subgraph.mainnetSubgraphId) {
+          this.yearnSubgraphEndpoint = `https://gateway.thegraph.com/api/${ctx.subgraph.subgraphKey}/subgraphs/id/${ctx.subgraph.mainnetSubgraphId}`;
         }
         break;
       case 250:
-        this.yearnSubgraphEndpoint = "https://api.thegraph.com/subgraphs/name/yearn/yearn-vaults-v2-fantom";
+        this.yearnSubgraphEndpoint =
+          ctx.subgraph?.fantomSubgraphEndpoint ||
+          "https://api.thegraph.com/subgraphs/name/yearn/yearn-vaults-v2-fantom";
         break;
       case 42161:
-        this.yearnSubgraphEndpoint = "https://api.thegraph.com/subgraphs/name/yearn/yearn-vaults-v2-arbitrum";
+        this.yearnSubgraphEndpoint =
+          ctx.subgraph?.arbitrumSubgraphEndpoint ||
+          "https://api.thegraph.com/subgraphs/name/yearn/yearn-vaults-v2-arbitrum";
         break;
       default:
         throw new SdkError(`No subgraph name for chain ${chainId}`);


### PR DESCRIPTION
## Description
Make all subgraph endpoints configurable

## Motivation and Context
We need to update the fantom subgraph to use this endpoint as the current one is currently not updating - https://github.com/yearn/yearn-watch/pull/287/files#diff-880b4d4064c28ef4d9a4808009d1df793532664a40f4ff4a96ba46ace81a3d2aR9
