### PR TITLE
feat: Supported Zap Vaults [WEB-1424]

### DIFF
--- a/src/interfaces/helpers/index.ts
+++ b/src/interfaces/helpers/index.ts
@@ -1,0 +1,1 @@
+export * from "./mergeZapperPropsWithAddressables";

--- a/src/interfaces/helpers/mergeZapperPropsWithAddressables.spec.ts
+++ b/src/interfaces/helpers/mergeZapperPropsWithAddressables.spec.ts
@@ -1,8 +1,8 @@
 import { createMockTokenMarketData, createMockVaultMetadata } from "../../test-utils/factories";
 import { mergeZapperPropsWithAddressables } from "./mergeZapperPropsWithAddressables";
 
-describe("mergeZapperProps", () => {
-  it("should set the zapper properties on a vault's metadata", async () => {
+describe("mergeZapperPropsWithAddressables", () => {
+  it("should set the zapper properties on an addressable", async () => {
     const vaultMetadataMock = {
       zappable: createMockVaultMetadata({
         displayName: "Zappable",

--- a/src/interfaces/helpers/mergeZapperPropsWithAddressables.spec.ts
+++ b/src/interfaces/helpers/mergeZapperPropsWithAddressables.spec.ts
@@ -1,0 +1,58 @@
+import { createMockTokenMarketData, createMockVaultMetadata } from "../../test-utils/factories";
+import { mergeZapperPropsWithAddressables } from "./mergeZapperPropsWithAddressables";
+
+describe("mergeZapperProps", () => {
+  it("should set the zapper properties on a vault's metadata", async () => {
+    const vaultMetadataMock = {
+      zappable: createMockVaultMetadata({
+        displayName: "Zappable",
+        address: "0x16de59092dae5ccf4a1e6439d611fd0653f0bd01", // not checksummed
+      }),
+      notZappable: createMockVaultMetadata({
+        displayName: "Not Zappable",
+        address: "0x6B175474E89094C44Da98b954EedeAC495271d0F",
+      }),
+    };
+
+    const vaultTokenMarketDataMock = {
+      zappable: createMockTokenMarketData({
+        label: "Zappable",
+        address: "0x16de59092dAE5CcF4A1E6439D611fd0653f0Bd01", // checksummed
+      }),
+      notInVaults: createMockTokenMarketData({
+        label: "Not in Vaults",
+        address: "0xd6aD7a6750A7593E092a9B218d66C0A814a3436e",
+      }),
+      random: createMockTokenMarketData({ label: "Random", address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48" }),
+    };
+
+    const actual = mergeZapperPropsWithAddressables(
+      [vaultMetadataMock.zappable, vaultMetadataMock.notZappable],
+      [
+        vaultTokenMarketDataMock.zappable.address,
+        vaultTokenMarketDataMock.notInVaults.address,
+        vaultTokenMarketDataMock.random.address,
+      ]
+    );
+
+    expect(actual.length).toEqual(2);
+    expect(actual).toEqual(
+      expect.arrayContaining([
+        {
+          ...vaultMetadataMock.zappable,
+          allowZapIn: true,
+          allowZapOut: true,
+          zapInWith: "zapperZapIn",
+          zapOutWith: "zapperZapOut",
+        },
+        {
+          ...vaultMetadataMock.notZappable,
+          allowZapIn: false,
+          allowZapOut: false,
+          zapInWith: undefined,
+          zapOutWith: undefined,
+        },
+      ])
+    );
+  });
+});

--- a/src/interfaces/helpers/mergeZapperPropsWithAddressables.ts
+++ b/src/interfaces/helpers/mergeZapperPropsWithAddressables.ts
@@ -3,7 +3,7 @@ import { getAddress } from "@ethersproject/address";
 import { Address, Addressable } from "../../types";
 
 /**
- * Helper function to set the zapper properties on a Addressable
+ * Helper function to set the zapper properties on an Addressable
  * @param addressables an array of objects with an address prop
  * @param supportedVaultAddresses the supported vault addresses
  * @returns the updated metadata

--- a/src/interfaces/helpers/mergeZapperPropsWithAddressables.ts
+++ b/src/interfaces/helpers/mergeZapperPropsWithAddressables.ts
@@ -1,0 +1,33 @@
+import { getAddress } from "@ethersproject/address";
+
+import { Address } from "../../types";
+
+/**
+ * Helper function to set the zapper properties on a vault's metadata
+ * @param addressables an array of objects with an address prop
+ * @param supportedVaultAddresses the supported vault addresses
+ * @returns the updated metadata
+ */
+export function mergeZapperPropsWithAddressables<T extends { address: Address }>(
+  addressables: T[],
+  supportedVaultAddresses: Address[]
+): T[] {
+  const supportedVaultAddressesSet = new Set(supportedVaultAddresses);
+
+  return addressables.map((addressable) => {
+    try {
+      const address = getAddress(addressable.address);
+      const isZappable = supportedVaultAddressesSet.has(address);
+
+      return {
+        ...addressable,
+        allowZapIn: isZappable,
+        allowZapOut: isZappable,
+        zapInWith: isZappable ? "zapperZapIn" : undefined,
+        zapOutWith: isZappable ? "zapperZapOut" : undefined,
+      };
+    } catch (error) {
+      return addressable;
+    }
+  });
+}

--- a/src/interfaces/helpers/mergeZapperPropsWithAddressables.ts
+++ b/src/interfaces/helpers/mergeZapperPropsWithAddressables.ts
@@ -3,7 +3,7 @@ import { getAddress } from "@ethersproject/address";
 import { Address, Addressable } from "../../types";
 
 /**
- * Helper function to set the zapper properties on a vault's metadata
+ * Helper function to set the zapper properties on a Addressable
  * @param addressables an array of objects with an address prop
  * @param supportedVaultAddresses the supported vault addresses
  * @returns the updated metadata

--- a/src/interfaces/helpers/mergeZapperPropsWithAddressables.ts
+++ b/src/interfaces/helpers/mergeZapperPropsWithAddressables.ts
@@ -1,6 +1,6 @@
 import { getAddress } from "@ethersproject/address";
 
-import { Address } from "../../types";
+import { Address, Addressable } from "../../types";
 
 /**
  * Helper function to set the zapper properties on a vault's metadata
@@ -8,7 +8,7 @@ import { Address } from "../../types";
  * @param supportedVaultAddresses the supported vault addresses
  * @returns the updated metadata
  */
-export function mergeZapperPropsWithAddressables<T extends { address: Address }>(
+export function mergeZapperPropsWithAddressables<T extends Addressable>(
   addressables: T[],
   supportedVaultAddresses: Address[]
 ): T[] {

--- a/src/interfaces/vault.spec.ts
+++ b/src/interfaces/vault.spec.ts
@@ -389,7 +389,7 @@ describe("VaultInterface", () => {
           });
         });
 
-        fdescribe("when is not provided", () => {
+        describe("when is not provided", () => {
           it("should get the vault's metadata", async () => {
             await vaultInterface.getDynamic([]);
 
@@ -680,7 +680,7 @@ describe("VaultInterface", () => {
           {
             ...tokenMock,
             icon: "token-mock-icon.png",
-            symbol: "ALIAS_TOKEN_SYMBOL",
+            symbol: "DEAD",
             metadata: {
               address: "0x001",
               decimals: "18",

--- a/src/interfaces/vault.spec.ts
+++ b/src/interfaces/vault.spec.ts
@@ -30,7 +30,6 @@ import {
   createMockEarningsUserData,
   createMockToken,
   createMockTokenBalance,
-  createMockTokenMarketData,
   createMockVaultMetadata,
 } from "../test-utils/factories";
 
@@ -1074,62 +1073,6 @@ describe("VaultInterface", () => {
           }
         });
       });
-    });
-  });
-
-  describe("mergeZapperProps", () => {
-    it("should set the zapper properties on a vault's metadata", async () => {
-      const vaultMetadataMock = {
-        zappable: createMockVaultMetadata({
-          displayName: "Zappable",
-          address: "0x16de59092dae5ccf4a1e6439d611fd0653f0bd01", // not checksummed
-        }),
-        notZappable: createMockVaultMetadata({
-          displayName: "Not Zappable",
-          address: "0x6B175474E89094C44Da98b954EedeAC495271d0F",
-        }),
-      };
-
-      const vaultTokenMarketDataMock = {
-        zappable: createMockTokenMarketData({
-          label: "Zappable",
-          address: "0x16de59092dAE5CcF4A1E6439D611fd0653f0Bd01", // checksummed
-        }),
-        notInVaults: createMockTokenMarketData({
-          label: "Not in Vaults",
-          address: "0xd6aD7a6750A7593E092a9B218d66C0A814a3436e",
-        }),
-        random: createMockTokenMarketData({ label: "Random", address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48" }),
-      };
-
-      const actual = vaultInterface.mergeZapperProps(
-        [vaultMetadataMock.zappable, vaultMetadataMock.notZappable],
-        [
-          vaultTokenMarketDataMock.zappable.address,
-          vaultTokenMarketDataMock.notInVaults.address,
-          vaultTokenMarketDataMock.random.address,
-        ]
-      );
-
-      expect(actual.length).toEqual(2);
-      expect(actual).toEqual(
-        expect.arrayContaining([
-          {
-            ...vaultMetadataMock.zappable,
-            allowZapIn: true,
-            allowZapOut: true,
-            zapInWith: "zapperZapIn",
-            zapOutWith: "zapperZapOut",
-          },
-          {
-            ...vaultMetadataMock.notZappable,
-            allowZapIn: false,
-            allowZapOut: false,
-            zapInWith: undefined,
-            zapOutWith: undefined,
-          },
-        ])
-      );
     });
   });
 });

--- a/src/interfaces/vault.ts
+++ b/src/interfaces/vault.ts
@@ -1,3 +1,4 @@
+import { getAddress } from "@ethersproject/address";
 import { BigNumber } from "@ethersproject/bignumber";
 import { MaxUint256 } from "@ethersproject/constants";
 import { CallOverrides, Contract } from "@ethersproject/contracts";
@@ -699,10 +700,10 @@ export class VaultInterface<T extends ChainId> extends ServiceInterface<T> {
     metadataOverrides: VaultMetadataOverrides[],
     vaultTokenMarketData: VaultTokenMarketData[]
   ): VaultMetadataOverrides[] {
-    const vaultTokenMarketDataAddresses = new Set(vaultTokenMarketData.map(({ address }) => address.toUpperCase()));
+    const vaultTokenMarketDataAddresses = new Set(vaultTokenMarketData.map(({ address }) => getAddress(address)));
 
     return metadataOverrides.map((metadataOverride) => {
-      const isZappable = vaultTokenMarketDataAddresses.has(metadataOverride.address.toUpperCase());
+      const isZappable = vaultTokenMarketDataAddresses.has(getAddress(metadataOverride.address));
 
       return {
         ...metadataOverride,

--- a/src/services/zapper.spec.ts
+++ b/src/services/zapper.spec.ts
@@ -55,7 +55,7 @@ describe("ZapperService", () => {
               })
             ) as jest.Mock
           );
-          getAddressMock.mockReturnValue("0x001");
+          getAddressMock.mockReturnValueOnce("0x001");
 
           const actualSupportedTokens = await zapperServiceService.supportedTokens();
 
@@ -80,32 +80,32 @@ describe("ZapperService", () => {
     );
   });
 
-  describe("tokenMarketData", () => {
+  describe("supportedVaultAddresses", () => {
     ([1, 1337] as ChainId[]).forEach((chainId) =>
       describe(`when chainId is ${chainId}`, () => {
         beforeEach(() => {
           zapperServiceService = new ZapperService(chainId, new Context({}));
         });
 
-        it("should return the vault token market data", async () => {
+        it("should return the zapper supported vault addresses without `null`s", async () => {
           const mockTokenMarketData = createMockTokenMarketData();
-
+          getAddressMock.mockReturnValueOnce(mockTokenMarketData.address);
           fetchSpy.mockImplementation(
             jest.fn(() =>
               Promise.resolve({
-                json: () => Promise.resolve([mockTokenMarketData]),
+                json: () => Promise.resolve([mockTokenMarketData, { address: null }]),
                 status: 200,
               })
             ) as jest.Mock
           );
 
-          const actual = await zapperServiceService.tokenMarketData();
+          const actual = await zapperServiceService.supportedVaultAddresses();
 
           expect(fetchSpy).toHaveBeenCalledTimes(1);
           expect(fetchSpy).toHaveBeenCalledWith(
             "https://api.zapper.fi/v1/protocols/yearn/token-market-data?network=ethereum&type=vault&api_key=ZAPPER_API_KEY"
           );
-          expect(actual).toEqual([mockTokenMarketData]);
+          expect(actual).toEqual([mockTokenMarketData.address]);
         });
       })
     );
@@ -115,7 +115,7 @@ describe("ZapperService", () => {
         zapperServiceService = new ZapperService(chainId, new Context({}));
 
         expect(async () => {
-          await zapperServiceService.tokenMarketData();
+          await zapperServiceService.supportedVaultAddresses();
         }).rejects.toThrow(`Only Ethereum is supported for token market data, got ${chainId}`);
       });
     });

--- a/src/services/zapper.ts
+++ b/src/services/zapper.ts
@@ -107,9 +107,9 @@ export class ZapperService extends Service {
 
   /**
    * Fetches vault token market data for the Yearn application
-   * @returns list of vault token market data
+   * @returns list of zapper supported vault addresses
    */
-  async tokenMarketData(): Promise<VaultTokenMarketData[]> {
+  async supportedVaultAddresses(): Promise<Address[]> {
     if (!isEthereum(this.chainId)) {
       throw new SdkError(`Only Ethereum is supported for token market data, got ${this.chainId}`);
     }
@@ -125,7 +125,9 @@ export class ZapperService extends Service {
       .then(handleHttpError)
       .then((res) => res.json());
 
-    return vaultTokenMarketData;
+    return vaultTokenMarketData
+      .map((vaultTokenMarketData: VaultTokenMarketData) => getAddress(vaultTokenMarketData.address))
+      .filter((address: string) => !!address);
   }
 
   /**

--- a/src/services/zapper.ts
+++ b/src/services/zapper.ts
@@ -1,11 +1,12 @@
 import { getAddress } from "@ethersproject/address";
 
-import { Chains } from "../chain";
+import { Chains, isEthereum } from "../chain";
 import { Service } from "../common";
 import { EthAddress, handleHttpError, usdc, ZeroAddress } from "../helpers";
-import { Address, Balance, BalancesMap, Integer, Token, ZapperToken } from "../types";
+import { Address, Balance, BalancesMap, Integer, SdkError, Token, ZapperToken } from "../types";
 import {
   GasPrice,
+  VaultTokenMarketData,
   ZapApprovalStateOutput,
   ZapApprovalTransactionOutput,
   ZapOutput,
@@ -102,6 +103,29 @@ export class ZapperService extends Service {
     });
     if (!Array.isArray(addresses)) return balances[addresses];
     return balances;
+  }
+
+  /**
+   * Fetches vault token market data for the Yearn application
+   * @returns list of vault token market data
+   */
+  async tokenMarketData(): Promise<VaultTokenMarketData[]> {
+    if (!isEthereum(this.chainId)) {
+      throw new SdkError(`Only Ethereum is supported for token market data, got ${this.chainId}`);
+    }
+
+    const url = "https://api.zapper.fi/v1/protocols/yearn/token-market-data";
+    const params = new URLSearchParams({
+      network: "ethereum",
+      type: "vault",
+      api_key: this.ctx.zapper,
+    });
+
+    const vaultTokenMarketData = await fetch(`${url}?${params}`)
+      .then(handleHttpError)
+      .then((res) => res.json());
+
+    return vaultTokenMarketData;
   }
 
   /**

--- a/src/test-utils/factories/index.ts
+++ b/src/test-utils/factories/index.ts
@@ -7,6 +7,7 @@ export * from "./earningsAssetData.factory";
 export * from "./earningsUserData.factory";
 export * from "./token.factory";
 export * from "./tokenBalance.factory";
+export * from "./tokenMarketData.factory";
 export * from "./tokenMetadata.factory";
 export * from "./vaultMetadata.factory";
 export * from "./zapperToken.factory";

--- a/src/test-utils/factories/tokenMarketData.factory.ts
+++ b/src/test-utils/factories/tokenMarketData.factory.ts
@@ -1,0 +1,39 @@
+import { VaultTokenMarketData } from "../../types";
+
+const DEFAULT_TOKEN_MARKET_DATA: VaultTokenMarketData = {
+  type: "vault",
+  category: "deposit",
+  network: "ethereum",
+  address: "0x16de59092dae5ccf4a1e6439d611fd0653f0bd01",
+  symbol: "yDAI",
+  label: "yDAI",
+  img: "https://storage.googleapis.com/zapper-fi-assets/apps/yearn.png",
+  decimals: 18,
+  price: 1.126570223844831,
+  pricePerShare: 1.126570223844831,
+  liquidity: 6899652.482441678,
+  supply: 6124476.163495696,
+  appId: "yearn",
+  isBlocked: true,
+  tokens: [
+    {
+      type: "base",
+      network: "ethereum",
+      address: "0x6b175474e89094c44da98b954eedeac495271d0f",
+      decimals: 18,
+      symbol: "DAI",
+      price: 1,
+      reserve: 6899652.482441678,
+      tokenImageUrl:
+        "https://storage.googleapis.com/zapper-fi-assets/tokens/ethereum/0x6b175474e89094c44da98b954eedeac495271d0f.png",
+    },
+  ],
+  appName: "Yearn",
+  appImageUrl: "https://storage.googleapis.com/zapper-fi-assets/apps/yearn.png",
+  protcolDisplay: "Yearn",
+};
+
+export const createMockTokenMarketData = (overwrites: Partial<VaultTokenMarketData> = {}): VaultTokenMarketData => ({
+  ...DEFAULT_TOKEN_MARKET_DATA,
+  ...overwrites,
+});

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -29,6 +29,11 @@ export class SdkError extends CustomError {
 export type Address = string;
 
 /**
+ * Type for anything that has an address property.
+ */
+export type Addressable = { address: Address };
+
+/**
  * Type alias for a stringified big number. SDK tries to be bignumber-lib
  * agnostic so integer values are returned as strings.
  */

--- a/src/types/custom/zapper.ts
+++ b/src/types/custom/zapper.ts
@@ -47,3 +47,56 @@ export enum ZapProtocol {
   PICKLE = "pickle",
   YEARN = "yearn",
 }
+
+type VaultTokenMarketDataCategory = "deposit" | "pool" | "wallet";
+
+export interface VaultTokenMarketData {
+  address: Address;
+  appId: "yearn";
+  appImageUrl: string;
+  appName: "Yearn";
+  apy?: number;
+  category: VaultTokenMarketDataCategory;
+  decimals: number;
+  img: string;
+  isBlocked: boolean;
+  label: string;
+  liquidity: number;
+  network: "ethereum";
+  price: number;
+  pricePerShare: number;
+  protcolDisplay: "Yearn";
+  supply: number;
+  symbol: string;
+  tokens: VaultTokenMarketDataToken[];
+  type: "vault";
+}
+
+type VaultTokenMarketDataType = "base" | "interest-bearing" | "pool" | "vault";
+
+interface VaultTokenMarketDataToken {
+  address: Address;
+  appId?: "yearn";
+  appImageUrl?: string;
+  appName?: "Yearn";
+  canExchange?: boolean;
+  category?: VaultTokenMarketDataType;
+  decimals: number;
+  exchangeAddress?: Address;
+  fee?: number;
+  hide?: boolean;
+  img?: string;
+  implementation?: "factoryV2";
+  label?: string;
+  liquidity?: number;
+  network: "ethereum";
+  price: number;
+  protcolDisplay?: "Yearn";
+  reserve: number;
+  supply?: number;
+  symbol: string;
+  tokenImageUrl?: string;
+  tokens?: unknown[]; // it goes a few levels deep
+  type: VaultTokenMarketDataType;
+  volume?: number | null;
+}

--- a/src/types/metadata.ts
+++ b/src/types/metadata.ts
@@ -121,4 +121,6 @@ export interface VaultMetadataOverrides {
   vaultNameOverride?: string;
   vaultSymbolOverride?: string;
   withdrawalsDisabled?: boolean;
+  zapInWith?: string;
+  zapOutWith?: string;
 }

--- a/src/types/metadata.ts
+++ b/src/types/metadata.ts
@@ -28,6 +28,8 @@ export interface VaultMetadata {
   withdrawalsDisabled?: boolean;
   allowZapIn?: boolean;
   allowZapOut?: boolean;
+  zapInWith?: string;
+  zapOutWith?: string;
   migrationContract?: Address;
   migrationTargetVault?: Address;
   vaultNameOverride?: string;


### PR DESCRIPTION
## Description

Provide information if a vault is supported to zap in/out

Metadata properties added in the following PR https://github.com/yearn/yearn-meta/pull/235

## Related Issue

https://linear.app/yearn/issue/WEB-1424/supported-zap-vaults

## Motivation and Context

We should get the if a vault is supported by zapper from https://api.zapper.fi/v1/protocols/yearn/token-market-data rather than assume it's supported

## How Has This Been Tested?

Added tests:

* src/services/zapper.spec.ts
* src/interfaces/vault.spec.ts

Tested locally with the frontend running the yalc'ed sdk

## Screenshots:

Frontend running locally, you can see that we have all the old/new zapper props (i.e. `allowZapIn`, `allowZapOut`, `zapInWith`, `zapOutWith`) set correctly for a "zappable" vault:

<img width="2352" alt="Screen Shot 2022-04-06 at 1 09 26 pm" src="https://user-images.githubusercontent.com/78794805/161909267-4629b1ab-112f-4a14-9ce7-8e6386027ba5.png">
