### PR TITLE
fix: Flatten the cache before filtering

### DIFF
--- a/src/interfaces/vault.ts
+++ b/src/interfaces/vault.ts
@@ -142,7 +142,7 @@ export class VaultInterface<T extends ChainId> extends ServiceInterface<T> {
   ): Promise<VaultDynamic[]> {
     const cached = await this.cachedFetcherGetDynamic.fetch();
     if (cached) {
-      return addresses ? cached.filter((vault) => addresses.includes(vault.address)) : cached;
+      return addresses ? cached.flat().filter((vault) => addresses.includes(vault.address)) : cached;
     }
 
     let metadataOverrides = vaultMetadataOverrides


### PR DESCRIPTION
## Description

The endpoint https://cache.yearn.finance/v1/chains/1/vaults/getDynamic is returning an array of arrays, however we are filtering the addresses as if it was a flat array. Wondering if anyone has some context on why we are grouping this array into chunks of 20 and if we should get a flat array from that endpoint?

It's working for https://cache.yearn.finance/v1/chains/1/vaults/get because it's a flat array and both are using exactly the same filtering, but unfortunately that only works for the flatten one:
```typescript
cached.filter((vault) => addresses.includes(vault.address));
```

## Related Issue

Fixes https://github.com/yearn/yearn-sdk/issues/274

## How Has This Been Tested?

Tested by running the sdk/fe locally

## Screenshots (if appropriate):

<img width="503" alt="Screen Shot 2022-04-09 at 10 47 22 am" src="https://user-images.githubusercontent.com/78794805/162549885-822cbdbb-2302-4cc5-b11d-981daa2de321.png">

<img width="437" alt="Screen Shot 2022-04-09 at 10 52 56 am" src="https://user-images.githubusercontent.com/78794805/162550100-d3d2fbf1-67a6-4f5b-b244-548f641fdbf5.png">

