### PR TITLE
don't include new apy in gross apy

### DIFF
--- a/src/interfaces/earnings.spec.ts
+++ b/src/interfaces/earnings.spec.ts
@@ -185,24 +185,25 @@ describe("EarningsInterface", () => {
     });
 
     describe("when there is an account", () => {
-      const accountAddress: Address = "0x001";
-      const apyMock = createMockApy({
-        net_apy: 42,
-      });
       const accountEarningsResponse = createMockAccountEarningsResponse();
       const tokensValueInUsdcMock: jest.Mock<Promise<BigNumber>> = jest.fn();
 
       beforeEach(() => {
         subgraphFetchQueryMock.mockResolvedValue(accountEarningsResponse);
-        visionApyMock.mockResolvedValue({
-          [accountAddress]: apyMock,
-        });
-        getAddressMock.mockReturnValue(accountAddress);
         (earningsInterface as any).tokensValueInUsdc = tokensValueInUsdcMock;
         tokensValueInUsdcMock.mockResolvedValue(new BigNumber(10));
+        getAddressMock.mockReturnValue("0x001");
       });
 
       it("should return an empty EarningsUserData", async () => {
+        const accountAddress: Address = "0x001";
+        visionApyMock.mockResolvedValue({
+          [accountAddress]: createMockApy({
+            net_apy: 42,
+          }),
+        });
+        getAddressMock.mockReturnValue(accountAddress);
+
         const actual = await earningsInterface.accountAssetsData(accountAddress);
 
         expect(visionApyMock).toHaveBeenCalledTimes(1);
@@ -221,8 +222,26 @@ describe("EarningsInterface", () => {
           holdings: "10",
         });
       });
+
+      it("should filter out new vaults for the estimated yield calculation", async () => {
+        const accountAddress: Address = "0x001";
+        visionApyMock.mockResolvedValue({
+          [accountAddress]: createMockApy({
+            net_apy: 42,
+            type: "new",
+          }),
+        });
+
+        const actual = await earningsInterface.accountAssetsData(accountAddress);
+
+        expect(visionApyMock).toHaveBeenCalledTimes(1);
+        expect(visionApyMock).toHaveBeenCalledWith([accountAddress]);
+        expect(getAddressMock).toHaveBeenCalledTimes(1);
+        expect(actual).toMatchObject({
+          estimatedYearlyYield: "0",
+        });
+      });
     });
-  });
 
   describe("assetsHistoricEarnings", () => {
     const assetHistoricEarnings = createMockAssetHistoricEarnings();

--- a/src/interfaces/earnings.spec.ts
+++ b/src/interfaces/earnings.spec.ts
@@ -242,6 +242,7 @@ describe("EarningsInterface", () => {
         });
       });
     });
+  });
 
   describe("assetsHistoricEarnings", () => {
     const assetHistoricEarnings = createMockAssetHistoricEarnings();

--- a/src/interfaces/earnings.ts
+++ b/src/interfaces/earnings.ts
@@ -156,7 +156,8 @@ export class EarningsInterface<C extends ChainId> extends ServiceInterface<C> {
       ? BigZero
       : assetsData
           .map((datum) => {
-            const apy = apys[datum.assetAddress]?.net_apy || 0;
+            const isNew = apys[datum.assetAddress]?.type === "new";
+            const apy = (!isNew && apys[datum.assetAddress]?.net_apy || 0)
             return new BigNumber(apy).times(datum.balanceUsdc).div(holdings);
           })
           .reduce((sum, value) => sum.plus(value));

--- a/src/interfaces/earnings.ts
+++ b/src/interfaces/earnings.ts
@@ -156,8 +156,10 @@ export class EarningsInterface<C extends ChainId> extends ServiceInterface<C> {
       ? BigZero
       : assetsData
           .map((datum) => {
-            const isNew = apys[datum.assetAddress]?.type === "new";
-            const apy = (!isNew && apys[datum.assetAddress]?.net_apy || 0)
+            if (apys[datum.assetAddress]?.type === "new") {
+              return BigZero;
+            }
+            const apy = apys[datum.assetAddress]?.net_apy || 0;
             return new BigNumber(apy).times(datum.balanceUsdc).div(holdings);
           })
           .reduce((sum, value) => sum.plus(value));


### PR DESCRIPTION
After depositing in Rocket Pool I got this APY. Thinking maybe we should remove new vault apy from gross apy.
![ryield](https://user-images.githubusercontent.com/26435/163670842-82aa5cf6-1998-4635-a175-1b6f22175143.png)
