### PR TITLE
build: Check only that the docs build on pull_request

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -35,3 +35,6 @@ jobs:
 
       - name: Build
         run: yarn build
+
+      - name: Build docs
+        run: yarn docs

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,9 +3,6 @@ on:
   push:
     branches:
       - master
-  pull_request:
-    branches:
-      - master
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

We should probably only check that the docs build and not Deploy to GitHub Pages when it's a PR

## Related Issue

Should make https://github.com/yearn/yearn-sdk/pull/281 green

<img width="896" alt="Screen Shot 2022-04-16 at 9 06 26 pm" src="https://user-images.githubusercontent.com/78794805/163672626-c6ae1a08-b6c4-4302-a8fe-64ae6ac632c0.png">


