### PR TITLE
feat: add populateApprove method to token interface

### DIFF
--- a/src/interfaces/token.spec.ts
+++ b/src/interfaces/token.spec.ts
@@ -31,9 +31,7 @@ const vaultsTokensMock = jest.fn();
 const ironBankBalancesMock = jest.fn();
 const ironBankTokensMock = jest.fn();
 const sendTransactionMock = jest.fn();
-const populateApproveMock = jest
-  .fn()
-  .mockResolvedValue(createMockPopulatedTransaction({ data: "PopulatedTransactionData" }));
+const populateApproveMock = jest.fn();
 const allowanceMock = jest.fn().mockResolvedValue("0");
 const partnerIsAllowedMock = jest.fn().mockReturnValue(true);
 
@@ -774,6 +772,10 @@ describe("TokenInterface", () => {
   });
 
   describe("populateApprove", () => {
+    beforeEach(() => {
+      populateApproveMock.mockResolvedValue(createMockPopulatedTransaction({ data: "PopulatedTransactionData" }));
+    });
+
     it("should return a populated transaction when approving non native token", async () => {
       const populateApproveResult = await tokenInterface.populateApprove(
         ownerAddress,
@@ -822,6 +824,7 @@ describe("TokenInterface", () => {
   describe("approve", () => {
     beforeEach(() => {
       sendTransactionMock.mockResolvedValue(true);
+      populateApproveMock.mockResolvedValue(createMockPopulatedTransaction({ data: "PopulatedTransactionData" }));
       tokenInterface.populateApprove = populateApproveMock;
     });
 

--- a/src/interfaces/token.ts
+++ b/src/interfaces/token.ts
@@ -260,7 +260,7 @@ export class TokenInterface<C extends ChainId> extends ServiceInterface<C> {
 
     const signer = this.ctx.provider.write.getSigner(ownerAddress);
     const tokenContract = new Contract(tokenAddress, TokenAbi, signer);
-    return await tokenContract.populateTransaction.approve(spenderAddress, amount, overrides);
+    return tokenContract.populateTransaction.approve(spenderAddress, amount, overrides);
   }
 
   /**

--- a/src/test-utils/factories/index.ts
+++ b/src/test-utils/factories/index.ts
@@ -5,6 +5,7 @@ export * from "./assetHistoricEarnings.factory";
 export * from "./balance.factory";
 export * from "./earningsAssetData.factory";
 export * from "./earningsUserData.factory";
+export * from "./populatedTransaction.factory";
 export * from "./token.factory";
 export * from "./tokenBalance.factory";
 export * from "./tokenMarketData.factory";

--- a/src/test-utils/factories/populatedTransaction.factory.ts
+++ b/src/test-utils/factories/populatedTransaction.factory.ts
@@ -1,0 +1,12 @@
+import { PopulatedTransaction } from "@ethersproject/contracts";
+
+const DEFAULT_POPULATED_TRANSACTION: PopulatedTransaction = {
+  data: "PopulatedTransactionData",
+};
+
+export const createMockPopulatedTransaction = (
+  overwrites: Partial<PopulatedTransaction> = {}
+): PopulatedTransaction => ({
+  ...DEFAULT_POPULATED_TRANSACTION,
+  ...overwrites,
+});


### PR DESCRIPTION
## Description

Add method to return an unsigned transaction for token approvals

## Motivation and Context

Add more composability between interfaces that dont need to execute transaction directly, like for simulations.

## How Has This Been Tested?

Tests in `src/interfaces/token.spec.ts`
