### PR TITLE
refactor: Update zapper's endpoints

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -3,6 +3,7 @@ import EventEmitter from "events";
 import { PartialDeep } from "type-fest";
 
 import { Address, Locale, SdkError } from "./types";
+import { encode } from "./utils";
 
 export interface AddressesOverride {
   lens?: Address;
@@ -121,8 +122,8 @@ export class Context implements ContextValue {
   }
 
   get zapper(): string {
-    if (this.ctx.zapper) return this.ctx.zapper;
-    throw new SdkError("zapper must be undefined in Context for this feature to work.");
+    if (this.ctx.zapper) return encode({ str: `${this.ctx.zapper}:`, encoding: "base64" });
+    throw new SdkError("zapperAuthToken must be undefined in Context for this feature to work.");
   }
 
   get etherscan(): string {

--- a/src/context.ts
+++ b/src/context.ts
@@ -123,7 +123,7 @@ export class Context implements ContextValue {
 
   get zapper(): string {
     if (this.ctx.zapper) return encode({ str: `${this.ctx.zapper}:`, encoding: "base64" });
-    throw new SdkError("zapperAuthToken must be undefined in Context for this feature to work.");
+    throw new SdkError("zapper must be undefined in Context for this feature to work.");
   }
 
   get etherscan(): string {

--- a/src/services/zapper.spec.ts
+++ b/src/services/zapper.spec.ts
@@ -103,7 +103,7 @@ describe("ZapperService", () => {
 
           expect(fetchSpy).toHaveBeenCalledTimes(1);
           expect(fetchSpy).toHaveBeenCalledWith(
-            "https://api.zapper.fi/v2/apps/yearn/tokens?network=ethereum&type=vault&api_key=ZAPPER_API_KEY"
+            "https://api.zapper.fi/v2/apps/yearn/tokens?network=ethereum&groupId=vault&api_key=ZAPPER_API_KEY"
           );
           expect(actual).toEqual([mockTokenMarketData.address]);
         });

--- a/src/services/zapper.spec.ts
+++ b/src/services/zapper.spec.ts
@@ -10,7 +10,7 @@ const getAddressMock = jest.fn();
 
 jest.mock("../context", () => ({
   Context: jest.fn().mockImplementation(() => ({
-    zapper: "ZAPPER_API_KEY",
+    zapper: "OTZlMGNjNTEtYTYyZS00MmNhLWFjZWUtOTEwZWE3ZDJhMjQxOg==",
   })),
 }));
 
@@ -103,7 +103,10 @@ describe("ZapperService", () => {
 
           expect(fetchSpy).toHaveBeenCalledTimes(1);
           expect(fetchSpy).toHaveBeenCalledWith(
-            "https://api.zapper.fi/v2/apps/yearn/tokens?network=ethereum&groupId=vault&api_key=ZAPPER_API_KEY"
+            "https://api.zapper.fi/v2/apps/yearn/tokens?network=ethereum&groupId=vault",
+            {
+              headers: { Authorization: `Basic OTZlMGNjNTEtYTYyZS00MmNhLWFjZWUtOTEwZWE3ZDJhMjQxOg==` },
+            }
           );
           expect(actual).toEqual([mockTokenMarketData.address]);
         });

--- a/src/services/zapper.spec.ts
+++ b/src/services/zapper.spec.ts
@@ -103,7 +103,7 @@ describe("ZapperService", () => {
 
           expect(fetchSpy).toHaveBeenCalledTimes(1);
           expect(fetchSpy).toHaveBeenCalledWith(
-            "https://api.zapper.fi/v1/protocols/yearn/token-market-data?network=ethereum&type=vault&api_key=ZAPPER_API_KEY"
+            "https://api.zapper.fi/v2/apps/yearn/tokens?network=ethereum&type=vault&api_key=ZAPPER_API_KEY"
           );
           expect(actual).toEqual([mockTokenMarketData.address]);
         });

--- a/src/services/zapper.ts
+++ b/src/services/zapper.ts
@@ -117,7 +117,7 @@ export class ZapperService extends Service {
     const url = "https://api.zapper.fi/v2/apps/yearn/tokens";
     const params = new URLSearchParams({
       network: "ethereum",
-      type: "vault",
+      groupId: "vault",
       api_key: this.ctx.zapper,
     });
 

--- a/src/services/zapper.ts
+++ b/src/services/zapper.ts
@@ -26,7 +26,7 @@ export class ZapperService extends Service {
    * @returns list of tokens supported by the zapper protocol.
    */
   async supportedTokens(): Promise<Token[]> {
-    const url = "https://api.zapper.fi/v1/prices";
+    const url = "https://api.zapper.fi/v2/prices";
     const params = new URLSearchParams({ api_key: this.ctx.zapper });
     const zapperTokens: ZapperToken[] = await fetch(`${url}?${params}`)
       .then(handleHttpError)
@@ -69,7 +69,7 @@ export class ZapperService extends Service {
   async balances<T extends Address>(addresses: T[] | T): Promise<BalancesMap<T> | Balance[]>;
 
   async balances<T extends Address>(addresses: T[] | T): Promise<BalancesMap<T> | Balance[]> {
-    const url = "https://api.zapper.fi/v1/protocols/tokens/balances";
+    const url = "https://api.zapper.fi/v2/apps/tokens/balances";
     const params = new URLSearchParams({
       "addresses[]": Array.isArray(addresses) ? addresses.join() : addresses,
       api_key: this.ctx.zapper,
@@ -114,7 +114,7 @@ export class ZapperService extends Service {
       throw new SdkError(`Only Ethereum is supported for token market data, got ${this.chainId}`);
     }
 
-    const url = "https://api.zapper.fi/v1/protocols/yearn/token-market-data";
+    const url = "https://api.zapper.fi/v2/apps/yearn/tokens";
     const params = new URLSearchParams({
       network: "ethereum",
       type: "vault",
@@ -135,7 +135,7 @@ export class ZapperService extends Service {
    * @returns gas prices
    */
   async gas(): Promise<GasPrice> {
-    const url = "https://api.zapper.fi/v1/gas-price";
+    const url = "https://api.zapper.fi/v2/gas-prices";
     const params = new URLSearchParams({
       api_key: this.ctx.zapper,
     });
@@ -156,7 +156,7 @@ export class ZapperService extends Service {
     token: Address,
     zapProtocol: ZapProtocol = ZapProtocol.YEARN
   ): Promise<ZapApprovalStateOutput> {
-    const url = `https://api.zapper.fi/v1/zap-in/vault/${zapProtocol}/approval-state`;
+    const url = `https://api.zapper.fi/v2/zap-in/vault/${zapProtocol}/approval-state`;
     const params = new URLSearchParams({
       ownerAddress: from,
       sellTokenAddress: token,
@@ -182,7 +182,7 @@ export class ZapperService extends Service {
     gasPrice: Integer,
     zapProtocol: ZapProtocol = ZapProtocol.YEARN
   ): Promise<ZapApprovalTransactionOutput> {
-    const url = `https://api.zapper.fi/v1/zap-in/vault/${zapProtocol}/approval-transaction`;
+    const url = `https://api.zapper.fi/v2/zap-in/vault/${zapProtocol}/approval-transaction`;
     const params = new URLSearchParams({
       gasPrice,
       ownerAddress: from,
@@ -207,7 +207,7 @@ export class ZapperService extends Service {
     token: Address,
     zapProtocol: ZapProtocol = ZapProtocol.YEARN
   ): Promise<ZapApprovalStateOutput> {
-    const url = `https://api.zapper.fi/v1/zap-out/vault/${zapProtocol}/approval-state`;
+    const url = `https://api.zapper.fi/v2/zap-out/vault/${zapProtocol}/approval-state`;
     const params = new URLSearchParams({
       ownerAddress: from,
       sellTokenAddress: token,
@@ -233,7 +233,7 @@ export class ZapperService extends Service {
     gasPrice: Integer,
     zapProtocol: ZapProtocol = ZapProtocol.YEARN
   ): Promise<ZapApprovalTransactionOutput> {
-    const url = `https://api.zapper.fi/v1/zap-out/vault/${zapProtocol}/approval-transaction`;
+    const url = `https://api.zapper.fi/v2/zap-out/vault/${zapProtocol}/approval-transaction`;
     const params = new URLSearchParams({
       gasPrice,
       ownerAddress: from,
@@ -275,7 +275,7 @@ export class ZapperService extends Service {
       sellToken = ZeroAddress;
     }
 
-    const url = `https://api.zapper.fi/v1/zap-in/vault/${zapProtocol}/transaction`;
+    const url = `https://api.zapper.fi/v2/zap-in/vault/${zapProtocol}/transaction`;
     const params = new URLSearchParams({
       affiliateAddress: ZAPPER_AFFILIATE_ADDRESS,
       ownerAddress: from,
@@ -325,7 +325,7 @@ export class ZapperService extends Service {
       toToken = ZeroAddress;
     }
 
-    const url = `https://api.zapper.fi/v1/zap-out/vault/${zapProtocol}/transaction`;
+    const url = `https://api.zapper.fi/v2/zap-out/vault/${zapProtocol}/transaction`;
     const params = new URLSearchParams({
       affiliateAddress: ZAPPER_AFFILIATE_ADDRESS,
       ownerAddress: from,

--- a/src/services/zapper.ts
+++ b/src/services/zapper.ts
@@ -74,7 +74,7 @@ export class ZapperService extends Service {
       "addresses[]": Array.isArray(addresses) ? addresses.join() : addresses,
       api_key: this.ctx.zapper,
     });
-    const balances = await fetch(`${url}?${params}`)
+    const { balances } = await fetch(`${url}?${params}`)
       .then(handleHttpError)
       .then((res) => res.json());
     Object.keys(balances).forEach((address) => {

--- a/src/services/zapper.ts
+++ b/src/services/zapper.ts
@@ -27,8 +27,9 @@ export class ZapperService extends Service {
    */
   async supportedTokens(): Promise<Token[]> {
     const url = "https://api.zapper.fi/v2/prices";
-    const params = new URLSearchParams({ api_key: this.ctx.zapper });
-    const zapperTokens: ZapperToken[] = await fetch(`${url}?${params}`)
+    const zapperTokens: ZapperToken[] = await fetch(url, {
+      headers: { Authorization: `Basic ${this.ctx.zapper}` },
+    })
       .then(handleHttpError)
       .then((res) => res.json());
 
@@ -72,9 +73,10 @@ export class ZapperService extends Service {
     const url = "https://api.zapper.fi/v2/apps/tokens/balances";
     const params = new URLSearchParams({
       "addresses[]": Array.isArray(addresses) ? addresses.join() : addresses,
-      api_key: this.ctx.zapper,
     });
-    const { balances } = await fetch(`${url}?${params}`)
+    const { balances } = await fetch(`${url}?${params}`, {
+      headers: { Authorization: `Basic ${this.ctx.zapper}` },
+    })
       .then(handleHttpError)
       .then((res) => res.json());
     Object.keys(balances).forEach((address) => {
@@ -118,10 +120,11 @@ export class ZapperService extends Service {
     const params = new URLSearchParams({
       network: "ethereum",
       groupId: "vault",
-      api_key: this.ctx.zapper,
     });
 
-    const vaultTokenMarketData = await fetch(`${url}?${params}`)
+    const vaultTokenMarketData = await fetch(`${url}?${params}`, {
+      headers: { Authorization: `Basic ${this.ctx.zapper}` },
+    })
       .then(handleHttpError)
       .then((res) => res.json());
 
@@ -139,7 +142,9 @@ export class ZapperService extends Service {
     const params = new URLSearchParams({
       eip1559: "false",
     });
-    const gas = await fetch(`${url}?${params}`)
+    const gas = await fetch(`${url}?${params}`, {
+      headers: { Authorization: `Basic ${this.ctx.zapper}` },
+    })
       .then(handleHttpError)
       .then((res) => res.json());
     return gas;
@@ -160,9 +165,10 @@ export class ZapperService extends Service {
     const params = new URLSearchParams({
       ownerAddress: from,
       sellTokenAddress: token,
-      api_key: this.ctx.zapper,
     });
-    const response: ZapApprovalStateOutput = await fetch(`${url}?${params}`)
+    const response: ZapApprovalStateOutput = await fetch(`${url}?${params}`, {
+      headers: { Authorization: `Basic ${this.ctx.zapper}` },
+    })
       .then(handleHttpError)
       .then((res) => res.json());
 
@@ -187,9 +193,10 @@ export class ZapperService extends Service {
       gasPrice,
       ownerAddress: from,
       sellTokenAddress: token,
-      api_key: this.ctx.zapper,
     });
-    const response: ZapApprovalTransactionOutput = await fetch(`${url}?${params}`)
+    const response: ZapApprovalTransactionOutput = await fetch(`${url}?${params}`, {
+      headers: { Authorization: `Basic ${this.ctx.zapper}` },
+    })
       .then(handleHttpError)
       .then((res) => res.json());
 
@@ -211,9 +218,10 @@ export class ZapperService extends Service {
     const params = new URLSearchParams({
       ownerAddress: from,
       sellTokenAddress: token,
-      api_key: this.ctx.zapper,
     });
-    const response: ZapApprovalStateOutput = await fetch(`${url}?${params}`)
+    const response: ZapApprovalStateOutput = await fetch(`${url}?${params}`, {
+      headers: { Authorization: `Basic ${this.ctx.zapper}` },
+    })
       .then(handleHttpError)
       .then((res) => res.json());
 
@@ -238,9 +246,10 @@ export class ZapperService extends Service {
       gasPrice,
       ownerAddress: from,
       sellTokenAddress: token,
-      api_key: this.ctx.zapper,
     });
-    const response: ZapApprovalTransactionOutput = await fetch(`${url}?${params}`)
+    const response: ZapApprovalTransactionOutput = await fetch(`${url}?${params}`, {
+      headers: { Authorization: `Basic ${this.ctx.zapper}` },
+    })
       .then(handleHttpError)
       .then((res) => res.json());
 
@@ -284,12 +293,13 @@ export class ZapperService extends Service {
       poolAddress: vault,
       gasPrice: gasPrice,
       slippagePercentage: slippagePercentage.toString(),
-      api_key: this.ctx.zapper,
       skipGasEstimate: skipGasEstimate ? "true" : "false",
       ...((partnerId && { partnerId }) || {}),
     });
 
-    const response: ZapOutput = await fetch(`${url}?${params}`)
+    const response: ZapOutput = await fetch(`${url}?${params}`, {
+      headers: { Authorization: `Basic ${this.ctx.zapper}` },
+    })
       .then(handleHttpError)
       .then((res) => res.json());
 
@@ -334,11 +344,12 @@ export class ZapperService extends Service {
       poolAddress: vault,
       gasPrice: gasPrice,
       slippagePercentage: slippagePercentage.toString(),
-      api_key: this.ctx.zapper,
       skipGasEstimate: skipGasEstimate ? "true" : "false",
       ...(signature && { signature }),
     });
-    const response: ZapOutput = await fetch(`${url}?${params}`)
+    const response: ZapOutput = await fetch(`${url}?${params}`, {
+      headers: { Authorization: `Basic ${this.ctx.zapper}` },
+    })
       .then(handleHttpError)
       .then((res) => res.json());
 

--- a/src/services/zapper.ts
+++ b/src/services/zapper.ts
@@ -335,7 +335,6 @@ export class ZapperService extends Service {
       gasPrice: gasPrice,
       slippagePercentage: slippagePercentage.toString(),
       api_key: this.ctx.zapper,
-      shouldSellEntireBalance: "true",
       skipGasEstimate: skipGasEstimate ? "true" : "false",
       ...(signature && { signature }),
     });

--- a/src/services/zapper.ts
+++ b/src/services/zapper.ts
@@ -137,7 +137,7 @@ export class ZapperService extends Service {
   async gas(): Promise<GasPrice> {
     const url = "https://api.zapper.fi/v2/gas-prices";
     const params = new URLSearchParams({
-      api_key: this.ctx.zapper,
+      eip1559: "false",
     });
     const gas = await fetch(`${url}?${params}`)
       .then(handleHttpError)

--- a/src/types/custom/zapper.ts
+++ b/src/types/custom/zapper.ts
@@ -4,6 +4,7 @@ import { Address, Integer } from "../common";
  * Simple gas prices in gwei
  */
 export interface GasPrice {
+  eip1559: boolean;
   standard: number;
   instant: number;
   fast: number;

--- a/src/utils/encode.spec.ts
+++ b/src/utils/encode.spec.ts
@@ -1,0 +1,9 @@
+import { encode } from "./encode";
+
+describe("encode", () => {
+  it("should encode a string to the specified encoding", () => {
+    const actual = encode({ str: "96e0cc51-a62e-42ca-acee-910ea7d2a241:", encoding: "base64" });
+
+    expect(actual).toEqual("OTZlMGNjNTEtYTYyZS00MmNhLWFjZWUtOTEwZWE3ZDJhMjQxOg==");
+  });
+});

--- a/src/utils/encode.ts
+++ b/src/utils/encode.ts
@@ -1,0 +1,3 @@
+export function encode({ str, encoding }: { str: string; encoding: "base64" }): string {
+  return Buffer.from(str, "binary").toString(encoding);
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,1 +1,2 @@
+export * from "./encode";
 export * from "./parser";


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

Use the new zapper endpoints.

* `v2/apps/tokens/balances` now has the addresses inside "balances" (https://github.com/yearn/yearn-sdk/pull/284/commits/4e3371078c6681cd67390ccc9e34eb66ec12832c addresses that)

## Related Issue

<!--- Please link to the issue here -->

https://medium.com/zapper-protocol/updates-to-zappers-public-apis-4933a2967f57

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Old endpoints have been deprecated

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

* Hit the v2 endpoints to make sure the results were the same as the v1;
* Yalc'ed the SDK into the FE;
* Added `src/utils/encode.spec.ts` to test the base64 encoding.

## Screenshots (if appropriate):

<img width="2352" alt="Screen Shot 2022-04-26 at 8 28 16 pm" src="https://user-images.githubusercontent.com/78794805/165280495-16eaeec0-d54e-499f-be4a-3b38b39ff8bb.png">

... more in the files