### PR TITLE
feat: add localization for meta endpoints

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -157,6 +157,6 @@ export class Context implements ContextValue {
   }
 
   get locale(): string {
-    return this.ctx.locale || 'en';
+    return this.ctx.locale || "en";
   }
 }

--- a/src/context.ts
+++ b/src/context.ts
@@ -65,6 +65,7 @@ export interface ContextValue {
   cache?: CacheConfiguration;
   subgraph?: SubgraphConfiguration;
   partnerId?: string;
+  locale?: string;
 }
 
 const DefaultContext: ContextValue = {
@@ -153,5 +154,9 @@ export class Context implements ContextValue {
 
   get partnerId(): string | undefined {
     return this.ctx.partnerId;
+  }
+
+  get locale(): string {
+    return this.ctx.locale || 'en';
   }
 }

--- a/src/context.ts
+++ b/src/context.ts
@@ -2,7 +2,7 @@ import { JsonRpcProvider } from "@ethersproject/providers";
 import EventEmitter from "events";
 import { PartialDeep } from "type-fest";
 
-import { Address, SdkError } from "./types";
+import { Address, Locale, SdkError } from "./types";
 
 export interface AddressesOverride {
   lens?: Address;
@@ -65,7 +65,7 @@ export interface ContextValue {
   cache?: CacheConfiguration;
   subgraph?: SubgraphConfiguration;
   partnerId?: string;
-  locale?: string;
+  locale?: Locale;
 }
 
 const DefaultContext: ContextValue = {
@@ -156,7 +156,7 @@ export class Context implements ContextValue {
     return this.ctx.partnerId;
   }
 
-  get locale(): string {
+  get locale(): Locale {
     return this.ctx.locale || "en";
   }
 }

--- a/src/interfaces/strategy.ts
+++ b/src/interfaces/strategy.ts
@@ -151,7 +151,7 @@ export class StrategyInterface<T extends ChainId> extends ServiceInterface<T> {
         const metadata: StrategyMetadata = {
           address: strategy.address,
           name: metadatum?.name || strategy.name || "Strategy",
-          description: metadatum?.description ?? "I don't have a description for this strategy yet",
+          description: metadatum?.localization[this.ctx.locale].description ?? "I don't have a description for this strategy yet",
           protocols: metadatum?.protocols ?? [],
         };
 

--- a/src/interfaces/strategy.ts
+++ b/src/interfaces/strategy.ts
@@ -151,7 +151,8 @@ export class StrategyInterface<T extends ChainId> extends ServiceInterface<T> {
         const metadata: StrategyMetadata = {
           address: strategy.address,
           name: metadatum?.name || strategy.name || "Strategy",
-          description: metadatum?.localization[this.ctx.locale]?.description ?? "I don't have a description for this strategy yet",
+          description:
+            metadatum?.localization[this.ctx.locale]?.description ?? "I don't have a description for this strategy yet",
           protocols: metadatum?.protocols ?? [],
         };
 

--- a/src/interfaces/strategy.ts
+++ b/src/interfaces/strategy.ts
@@ -156,7 +156,7 @@ export class StrategyInterface<T extends ChainId> extends ServiceInterface<T> {
             obj: metadatum,
             property: "description",
             locale: this.ctx.locale,
-            fallback: "I don't have a description for this strategy yet",
+            fallback: "Vault strategy missing",
           }),
           protocols: metadatum?.protocols ?? [],
         };

--- a/src/interfaces/strategy.ts
+++ b/src/interfaces/strategy.ts
@@ -151,7 +151,7 @@ export class StrategyInterface<T extends ChainId> extends ServiceInterface<T> {
         const metadata: StrategyMetadata = {
           address: strategy.address,
           name: metadatum?.name || strategy.name || "Strategy",
-          description: metadatum?.localization[this.ctx.locale].description ?? "I don't have a description for this strategy yet",
+          description: metadatum?.localization[this.ctx.locale]?.description ?? "I don't have a description for this strategy yet",
           protocols: metadatum?.protocols ?? [],
         };
 

--- a/src/interfaces/strategy.ts
+++ b/src/interfaces/strategy.ts
@@ -7,6 +7,7 @@ import { ChainId } from "../chain";
 import { ServiceInterface } from "../common";
 import { Address, StrategiesMetadata, StrategyMetadata } from "../types";
 import { VaultStrategiesMetadata } from "../types/strategy";
+import { getLocalizedString } from "../utils/localization";
 
 interface VaultData {
   address: Address;
@@ -151,8 +152,12 @@ export class StrategyInterface<T extends ChainId> extends ServiceInterface<T> {
         const metadata: StrategyMetadata = {
           address: strategy.address,
           name: metadatum?.name || strategy.name || "Strategy",
-          description:
-            metadatum?.localization[this.ctx.locale]?.description ?? "I don't have a description for this strategy yet",
+          description: getLocalizedString({
+            obj: metadatum,
+            property: "description",
+            locale: this.ctx.locale,
+            fallback: "I don't have a description for this strategy yet",
+          }),
           protocols: metadatum?.protocols ?? [],
         };
 

--- a/src/services/meta.spec.ts
+++ b/src/services/meta.spec.ts
@@ -56,11 +56,17 @@ describe("MetaService", () => {
     });
 
     it("should fetch all tokens metadata from the addresses given and replace localized strings", async () => {
-      meta = new MetaService(1, new Context({ locale: 'es' }));
+      meta = new MetaService(1, new Context({ locale: "es" }));
 
-      const tokenMetadata1 = createMockTokenMetadata({ address: "0x001", localization: { es: { name: '', description: 'Spanish text' }, } });
+      const tokenMetadata1 = createMockTokenMetadata({
+        address: "0x001",
+        localization: { es: { name: "", description: "Spanish text" } },
+      });
       const tokenMetadataIgnored = createMockTokenMetadata({ address: "0x002" });
-      const tokenMetadata2 = createMockTokenMetadata({ address: "0x003", localization: { es: { name: '', description: 'Spanish text' }, } });
+      const tokenMetadata2 = createMockTokenMetadata({
+        address: "0x003",
+        localization: { es: { name: "", description: "Spanish text" } },
+      });
       (global.fetch as any).mockResolvedValueOnce({
         ok: true,
         json: async () => [tokenMetadata1, tokenMetadataIgnored, tokenMetadata2],
@@ -70,13 +76,18 @@ describe("MetaService", () => {
 
       expect(global.fetch).toHaveBeenCalledTimes(1);
       expect(global.fetch).toHaveBeenCalledWith("https://meta.yearn.network/tokens/1/all");
-      expect(actual).toEqual(expect.arrayContaining([{
-        ...tokenMetadata1,
-        description: 'Spanish text',
-      }, {
-        ...tokenMetadata2,
-        description: 'Spanish text',
-      }]));
+      expect(actual).toEqual(
+        expect.arrayContaining([
+          {
+            ...tokenMetadata1,
+            description: "Spanish text",
+          },
+          {
+            ...tokenMetadata2,
+            description: "Spanish text",
+          },
+        ])
+      );
       expect(actual).not.toEqual(
         expect.arrayContaining([
           expect.objectContaining({

--- a/src/services/meta.spec.ts
+++ b/src/services/meta.spec.ts
@@ -13,6 +13,12 @@ describe("MetaService", () => {
   beforeEach(() => {
     meta = new MetaService(1, new Context({}));
     jest.spyOn(console, "error").mockImplementation();
+    const tokenMetadata1 = createMockTokenMetadata({ address: "0x001" });
+    const tokenMetadata2 = createMockTokenMetadata({ address: "0x002" });
+    (global.fetch as any).mockResolvedValue({
+      ok: true,
+      json: async () => [tokenMetadata1, tokenMetadata2],
+    });
   });
 
   afterEach(() => {
@@ -40,6 +46,37 @@ describe("MetaService", () => {
       expect(global.fetch).toHaveBeenCalledTimes(1);
       expect(global.fetch).toHaveBeenCalledWith("https://meta.yearn.network/tokens/1/all");
       expect(actual).toEqual(expect.arrayContaining([tokenMetadata1, tokenMetadata2]));
+      expect(actual).not.toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            address: "0x002",
+          }),
+        ])
+      );
+    });
+
+    it("should fetch all tokens metadata from the addresses given and replace localized strings", async () => {
+      meta = new MetaService(1, new Context({ locale: 'es' }));
+
+      const tokenMetadata1 = createMockTokenMetadata({ address: "0x001", localization: { es: { name: '', description: 'Spanish text' }, } });
+      const tokenMetadataIgnored = createMockTokenMetadata({ address: "0x002" });
+      const tokenMetadata2 = createMockTokenMetadata({ address: "0x003", localization: { es: { name: '', description: 'Spanish text' }, } });
+      (global.fetch as any).mockResolvedValueOnce({
+        ok: true,
+        json: async () => [tokenMetadata1, tokenMetadataIgnored, tokenMetadata2],
+      });
+
+      const actual = await meta.tokens(["0x001", "0x003"]);
+
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+      expect(global.fetch).toHaveBeenCalledWith("https://meta.yearn.network/tokens/1/all");
+      expect(actual).toEqual(expect.arrayContaining([{
+        ...tokenMetadata1,
+        description: 'Spanish text',
+      }, {
+        ...tokenMetadata2,
+        description: 'Spanish text',
+      }]));
       expect(actual).not.toEqual(
         expect.arrayContaining([
           expect.objectContaining({

--- a/src/services/meta.ts
+++ b/src/services/meta.ts
@@ -1,5 +1,6 @@
 import { Service } from "../common";
 import { Address, SdkError, StrategiesMetadata, TokenMetadata, VaultMetadataOverrides } from "../types";
+import { getLocalizedString } from "../utils/localization";
 
 const META_URL = "https://meta.yearn.network";
 
@@ -16,10 +17,12 @@ export class MetaService extends Service {
     if (!addresses) {
       return tokensMetadata.map((tokenMetadata: TokenMetadata) => ({
         ...tokenMetadata,
-        description:
-          tokenMetadata.localization[this.ctx.locale]?.description ??
-          tokenMetadata.description ??
-          "I don't have a description for this token yet",
+        description: getLocalizedString({
+          obj: tokenMetadata,
+          property: "description",
+          locale: this.ctx.locale,
+          fallback: "I don't have a description for this token yet",
+        }),
       }));
     }
 
@@ -27,10 +30,12 @@ export class MetaService extends Service {
       .filter((tokenMetadata: TokenMetadata) => addresses.includes(tokenMetadata.address))
       .map((tokenMetadata: TokenMetadata) => ({
         ...tokenMetadata,
-        description:
-          tokenMetadata.localization[this.ctx.locale]?.description ??
-          tokenMetadata.description ??
-          "I don't have a description for this token yet",
+        description: getLocalizedString({
+          obj: tokenMetadata,
+          property: "description",
+          locale: this.ctx.locale,
+          fallback: "I don't have a description for this token yet",
+        }),
       }));
   }
 
@@ -44,10 +49,12 @@ export class MetaService extends Service {
 
       const returnedValue: TokenMetadata = await response.json();
 
-      returnedValue.description =
-        returnedValue.localization[this.ctx.locale]?.description ??
-        returnedValue.description ??
-        "I don't have a description for this token yet";
+      returnedValue.description = getLocalizedString({
+        obj: returnedValue,
+        property: "description",
+        locale: this.ctx.locale,
+        fallback: "I don't have a description for this token yet",
+      });
 
       return returnedValue;
     } catch (error) {

--- a/src/services/meta.ts
+++ b/src/services/meta.ts
@@ -9,19 +9,29 @@ const META_URL = "https://meta.yearn.network";
  */
 export class MetaService extends Service {
   async tokens(addresses?: Address[]): Promise<TokenMetadata[]> {
-    const tokensMetadata: TokenMetadata[] = await fetch(`${META_URL}/tokens/${this.chainId}/all`).then((res) => res.json());
+    const tokensMetadata: TokenMetadata[] = await fetch(`${META_URL}/tokens/${this.chainId}/all`).then((res) =>
+      res.json()
+    );
 
     if (!addresses) {
       return tokensMetadata.map((tokenMetadata: TokenMetadata) => ({
         ...tokenMetadata,
-        description: (tokenMetadata.localization[this.ctx.locale]?.description ?? tokenMetadata.description) ?? "I don't have a description for this token yet"
+        description:
+          tokenMetadata.localization[this.ctx.locale]?.description ??
+          tokenMetadata.description ??
+          "I don't have a description for this token yet",
       }));
     }
 
-    return tokensMetadata.filter((tokenMetadata: TokenMetadata) => addresses.includes(tokenMetadata.address)).map((tokenMetadata: TokenMetadata) => ({
-      ...tokenMetadata,
-      description: tokenMetadata.localization[this.ctx.locale]?.description ?? tokenMetadata.description ?? "I don't have a description for this token yet"
-    }));
+    return tokensMetadata
+      .filter((tokenMetadata: TokenMetadata) => addresses.includes(tokenMetadata.address))
+      .map((tokenMetadata: TokenMetadata) => ({
+        ...tokenMetadata,
+        description:
+          tokenMetadata.localization[this.ctx.locale]?.description ??
+          tokenMetadata.description ??
+          "I don't have a description for this token yet",
+      }));
   }
 
   async token(address: Address): Promise<TokenMetadata | null> {
@@ -34,7 +44,10 @@ export class MetaService extends Service {
 
       const returnedValue: TokenMetadata = await response.json();
 
-      returnedValue.description = (returnedValue.localization[this.ctx.locale]?.description ?? returnedValue.description) ?? "I don't have a description for this token yet"
+      returnedValue.description =
+        returnedValue.localization[this.ctx.locale]?.description ??
+        returnedValue.description ??
+        "I don't have a description for this token yet";
 
       return returnedValue;
     } catch (error) {

--- a/src/services/meta.ts
+++ b/src/services/meta.ts
@@ -14,13 +14,13 @@ export class MetaService extends Service {
     if (!addresses) {
       return tokensMetadata.map((tokenMetadata: TokenMetadata) => ({
         ...tokenMetadata,
-        description: tokenMetadata.localization[this.ctx.locale].description ?? "I don't have a description for this token yet"
+        description: (tokenMetadata.localization[this.ctx.locale]?.description ?? tokenMetadata.description) ?? "I don't have a description for this token yet"
       }));
     }
 
     return tokensMetadata.filter((tokenMetadata: TokenMetadata) => addresses.includes(tokenMetadata.address)).map((tokenMetadata: TokenMetadata) => ({
       ...tokenMetadata,
-      description: tokenMetadata.localization[this.ctx.locale].description ?? "I don't have a description for this token yet"
+      description: tokenMetadata.localization[this.ctx.locale]?.description ?? tokenMetadata.description ?? "I don't have a description for this token yet"
     }));
   }
 
@@ -34,7 +34,7 @@ export class MetaService extends Service {
 
       const returnedValue: TokenMetadata = await response.json();
 
-      returnedValue.description = returnedValue.localization[this.ctx.locale].description ?? "I don't have a description for this token yet"
+      returnedValue.description = (returnedValue.localization[this.ctx.locale]?.description ?? returnedValue.description) ?? "I don't have a description for this token yet"
 
       return returnedValue;
     } catch (error) {

--- a/src/services/meta.ts
+++ b/src/services/meta.ts
@@ -21,7 +21,7 @@ export class MetaService extends Service {
           obj: tokenMetadata,
           property: "description",
           locale: this.ctx.locale,
-          fallback: "I don't have a description for this token yet",
+          fallback: "Token description missing",
         }),
       }));
     }
@@ -34,7 +34,7 @@ export class MetaService extends Service {
           obj: tokenMetadata,
           property: "description",
           locale: this.ctx.locale,
-          fallback: "I don't have a description for this token yet",
+          fallback: "Token description missing",
         }),
       }));
   }
@@ -53,7 +53,7 @@ export class MetaService extends Service {
         obj: returnedValue,
         property: "description",
         locale: this.ctx.locale,
-        fallback: "I don't have a description for this token yet",
+        fallback: "Token description missing",
       });
 
       return returnedValue;

--- a/src/services/meta.ts
+++ b/src/services/meta.ts
@@ -9,13 +9,19 @@ const META_URL = "https://meta.yearn.network";
  */
 export class MetaService extends Service {
   async tokens(addresses?: Address[]): Promise<TokenMetadata[]> {
-    const tokensMetadata = await fetch(`${META_URL}/tokens/${this.chainId}/all`).then((res) => res.json());
+    const tokensMetadata: TokenMetadata[] = await fetch(`${META_URL}/tokens/${this.chainId}/all`).then((res) => res.json());
 
     if (!addresses) {
-      return tokensMetadata;
+      return tokensMetadata.map((tokenMetadata: TokenMetadata) => ({
+        ...tokenMetadata,
+        description: tokenMetadata.localization[this.ctx.locale].description ?? "I don't have a description for this token yet"
+      }));
     }
 
-    return tokensMetadata.filter((tokenMetadata: TokenMetadata) => addresses.includes(tokenMetadata.address));
+    return tokensMetadata.filter((tokenMetadata: TokenMetadata) => addresses.includes(tokenMetadata.address)).map((tokenMetadata: TokenMetadata) => ({
+      ...tokenMetadata,
+      description: tokenMetadata.localization[this.ctx.locale].description ?? "I don't have a description for this token yet"
+    }));
   }
 
   async token(address: Address): Promise<TokenMetadata | null> {
@@ -26,7 +32,11 @@ export class MetaService extends Service {
         throw new SdkError(`Failed to fetch token with address "${address}". HTTP error: ${response.status}`);
       }
 
-      return response.json();
+      const returnedValue: TokenMetadata = await response.json();
+
+      returnedValue.description = returnedValue.localization[this.ctx.locale].description ?? "I don't have a description for this token yet"
+
+      return returnedValue;
     } catch (error) {
       console.error(error);
     }

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -55,3 +55,8 @@ export type Unit = string;
  * Utility type to describe a map of predefined keys with the same value.
  */
 export type TypedMap<K extends string | number | symbol, V> = { [key in K]: V };
+
+/**
+ * Accepted locales.
+ */
+export type Locale = "de" | "el" | "en" | "es" | "fr" | "hi" | "id" | "ja" | "pt" | "ru" | "tr" | "vi" | "zh";

--- a/src/types/metadata.ts
+++ b/src/types/metadata.ts
@@ -72,6 +72,11 @@ export type Metadata = {
  */
 export type TypeId = keyof Metadata;
 
+export interface Localization {
+  name: string;
+  description: string;
+}
+
 /**
  * Token metadata from yearn-meta
  */
@@ -83,7 +88,7 @@ export interface TokenMetadata {
   tokenIconOverride?: string;
   tokenSymbolOverride?: string;
   tokenNameOverride?: string;
-  localization: Record<string, unknown>;
+  localization: Record<string, Localization>;
 }
 
 export interface StrategyMetadata {
@@ -96,6 +101,7 @@ export interface StrategyMetadata {
 export interface StrategiesMetadata {
   name: string;
   description: string;
+  localization: Record<string, Localization>;
   addresses: Address[];
   protocols: string[];
 }

--- a/src/types/metadata.ts
+++ b/src/types/metadata.ts
@@ -1,4 +1,4 @@
-import { Address, Integer } from "./common";
+import { Address, Integer, Locale } from "./common";
 import { EarningsDayData } from "./custom/earnings";
 import { Apy } from "./custom/vault";
 import { VaultStrategiesMetadata } from "./strategy";
@@ -72,11 +72,12 @@ export type Metadata = {
  */
 export type TypeId = keyof Metadata;
 
-export interface Localization {
-  name: string;
+export interface LocalizedProperties {
+  name?: string;
   description: string;
 }
 
+export type Localization = Partial<Record<Locale, LocalizedProperties>>;
 /**
  * Token metadata from yearn-meta
  */
@@ -88,7 +89,7 @@ export interface TokenMetadata {
   tokenIconOverride?: string;
   tokenSymbolOverride?: string;
   tokenNameOverride?: string;
-  localization: Record<string, Localization>;
+  localization: Localization;
 }
 
 export interface StrategyMetadata {
@@ -101,7 +102,7 @@ export interface StrategyMetadata {
 export interface StrategiesMetadata {
   name: string;
   description: string;
-  localization: Record<string, Localization>;
+  localization: Localization;
   addresses: Address[];
   protocols: string[];
 }

--- a/src/utils/localization.ts
+++ b/src/utils/localization.ts
@@ -1,0 +1,21 @@
+import { Locale, Localization } from "../types";
+
+interface LocalizationObject {
+  localization: Localization;
+}
+type LocalizedObject<T extends string> = LocalizationObject & {
+  [key in T]: string;
+};
+// interface LocalizedObject<T> extends { localization: Localization; };
+
+export const getLocalizedString = <T extends string>({
+  obj,
+  property,
+  locale,
+  fallback,
+}: {
+  obj?: LocalizedObject<T>;
+  property: T;
+  locale: Locale;
+  fallback: string;
+}): string => obj?.localization[locale]?.description ?? (obj && obj[property]) ?? fallback;

--- a/src/utils/localization.ts
+++ b/src/utils/localization.ts
@@ -6,7 +6,6 @@ interface LocalizationObject {
 type LocalizedObject<T extends string> = LocalizationObject & {
   [key in T]: string;
 };
-// interface LocalizedObject<T> extends { localization: Localization; };
 
 export const getLocalizedString = <T extends string>({
   obj,
@@ -15,7 +14,7 @@ export const getLocalizedString = <T extends string>({
   fallback,
 }: {
   obj?: LocalizedObject<T>;
-  property: T;
+  property?: T;
   locale: Locale;
   fallback: string;
-}): string => obj?.localization[locale]?.description ?? (obj && obj[property]) ?? fallback;
+}): string => obj?.localization[locale]?.description ?? (obj && property && obj[property]) ?? fallback;


### PR DESCRIPTION
## Description

Adds localization to the sdk, accepting 

## Related Issue


## Motivation and Context

We want to show localized strings for strategies and tokens data on any provided rfrom the sdk

## How Has This Been Tested?

Manually and some unit tests

## Screenshots (if appropriate):
(Screenshot for initializing sdk with 'es' locale while main application is in 'en' locale)
<img width="1344" alt="Screenshot 2022-05-02 at 17 15 55" src="https://user-images.githubusercontent.com/94012134/166319315-6cdc0a57-9e61-44bd-91fb-c136defa634a.png">


