### PR TITLE
feat: add propertiesAggregatorService

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -64,6 +64,7 @@ export enum ContractAddressId {
   zapperZapIn = "ZAPPER_ZAP_IN",
   zapperZapOut = "ZAPPER_ZAP_OUT",
   pickleZapIn = "PICKLE_ZAP_IN",
+  propertiesAggregator = "PROPERTIES_AGGREGATOR",
   unused = "UNUSED",
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,6 +53,7 @@ export { RegistryV2Adapter } from "./services/adapters/registry";
 export { AssetService } from "./services/assets";
 export { LensService } from "./services/lens";
 export { OracleService } from "./services/oracle";
+export { PropertiesAggregatorService } from "./services/propertiesAggregator";
 export { SubgraphService } from "./services/subgraph";
 export { TelegramService } from "./services/telegram";
 export { VisionService } from "./services/vision";

--- a/src/services/propertiesAggregator.spec.ts
+++ b/src/services/propertiesAggregator.spec.ts
@@ -1,0 +1,86 @@
+import { ParamType } from "@ethersproject/abi";
+
+import { ChainId } from "../chain";
+import { ContractAddressId } from "../common";
+import { Context } from "../context";
+import { AddressProvider } from "./addressProvider";
+import { PropertiesAggregatorService } from "./propertiesAggregator";
+
+const decodeMock = jest.fn().mockResolvedValue("decoded");
+const targetAddress = "0x5D7201c10AfD0Ed1a1F408E321Ef0ebc7314B086";
+
+jest.mock("./addressProvider", () => ({
+  AddressProvider: jest.fn().mockImplementation(() => ({
+    addressById: jest.fn().mockResolvedValue(targetAddress),
+  })),
+}));
+
+jest.mock("@ethersproject/abi", () => {
+  const original = jest.requireActual("@ethersproject/abi");
+  return {
+    ...original,
+    AbiCoder: jest.fn().mockImplementation(() => ({
+      decode: decodeMock,
+    })),
+  };
+});
+
+describe("PropertiesAggregatorService", () => {
+  let propertiesAggregatorService: PropertiesAggregatorService<1>;
+  let mockedAddressProvider: AddressProvider<ChainId>;
+  let context: Context;
+  let getPropertyMock: jest.Mock;
+  let getPropertiesMock: jest.Mock;
+
+  beforeEach(() => {
+    mockedAddressProvider = new (AddressProvider as unknown as jest.Mock<AddressProvider<ChainId>>)();
+    context = new Context({});
+    propertiesAggregatorService = new PropertiesAggregatorService(1, context, mockedAddressProvider);
+    getPropertyMock = jest.fn();
+    getPropertiesMock = jest.fn();
+    Object.defineProperty(propertiesAggregatorService, "_getContract", {
+      value: jest.fn().mockResolvedValue({
+        read: { getProperty: getPropertyMock, getProperties: getPropertiesMock },
+      }),
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("address provider type", () => {
+    it("should be properties aggregator service contract id", () => {
+      expect(PropertiesAggregatorService.contractId).toEqual(ContractAddressId.propertiesAggregator);
+    });
+  });
+
+  describe("getProperty", () => {
+    it("should call the properties aggregator contract's getProperty method", async () => {
+      const propertyName = "name";
+      const paramType = ParamType.from(`string ${propertyName}`);
+      await propertiesAggregatorService.getProperty({
+        target: targetAddress,
+        paramType: paramType,
+      });
+
+      expect(getPropertyMock).toHaveBeenCalledTimes(1);
+      expect(getPropertyMock).toHaveBeenCalledWith(targetAddress, propertyName);
+    });
+  });
+
+  describe("getProperty", () => {
+    beforeEach(() => {
+      getPropertiesMock.mockReturnValue(["firstResult", "secondResult"]);
+    });
+
+    it("should call the properties aggregator contract's getProperties method", async () => {
+      const paramTypes = [ParamType.from("string name"), ParamType.from("uint256 totalAssets")];
+      await propertiesAggregatorService.getProperties(targetAddress, paramTypes);
+      const propertyNames = paramTypes.map((type) => type.name);
+
+      expect(getPropertiesMock).toHaveBeenCalledTimes(1);
+      expect(getPropertiesMock).toHaveBeenCalledWith(targetAddress, propertyNames);
+    });
+  });
+});

--- a/src/services/propertiesAggregator.spec.ts
+++ b/src/services/propertiesAggregator.spec.ts
@@ -59,10 +59,7 @@ describe("PropertiesAggregatorService", () => {
     it("should call the properties aggregator contract's getProperty method", async () => {
       const propertyName = "name";
       const paramType = ParamType.from(`string ${propertyName}`);
-      await propertiesAggregatorService.getProperty({
-        target: targetAddress,
-        paramType: paramType,
-      });
+      await propertiesAggregatorService.getProperty(targetAddress, paramType);
 
       expect(getPropertyMock).toHaveBeenCalledTimes(1);
       expect(getPropertyMock).toHaveBeenCalledWith(targetAddress, propertyName);

--- a/src/services/propertiesAggregator.spec.ts
+++ b/src/services/propertiesAggregator.spec.ts
@@ -65,7 +65,7 @@ describe("PropertiesAggregatorService", () => {
     });
   });
 
-  describe("getProperty", () => {
+  describe("getProperties", () => {
     beforeEach(() => {
       getPropertiesMock.mockReturnValue(["firstResult", "secondResult"]);
     });

--- a/src/services/propertiesAggregator.spec.ts
+++ b/src/services/propertiesAggregator.spec.ts
@@ -6,7 +6,6 @@ import { Context } from "../context";
 import { AddressProvider } from "./addressProvider";
 import { PropertiesAggregatorService } from "./propertiesAggregator";
 
-const decodeMock = jest.fn().mockResolvedValue("decoded");
 const targetAddress = "0x5D7201c10AfD0Ed1a1F408E321Ef0ebc7314B086";
 
 jest.mock("./addressProvider", () => ({
@@ -19,9 +18,9 @@ jest.mock("@ethersproject/abi", () => {
   const original = jest.requireActual("@ethersproject/abi");
   return {
     ...original,
-    AbiCoder: jest.fn().mockImplementation(() => ({
-      decode: decodeMock,
-    })),
+    defaultAbiCoder: {
+      decode: jest.fn().mockReturnValue("decoded"),
+    },
   };
 });
 

--- a/src/services/propertiesAggregator.ts
+++ b/src/services/propertiesAggregator.ts
@@ -1,4 +1,4 @@
-import { AbiCoder, ParamType } from "@ethersproject/abi";
+import { defaultAbiCoder, ParamType } from "@ethersproject/abi";
 import { BigNumber } from "@ethersproject/bignumber";
 
 import { ChainId } from "../chain";
@@ -19,8 +19,6 @@ export class PropertiesAggregatorService<T extends ChainId> extends ContractServ
   ];
   static contractId = ContractAddressId.propertiesAggregator;
 
-  private coder = new AbiCoder();
-
   get contract(): Promise<WrappedContract> {
     return this._getContract(PropertiesAggregatorService.abi, PropertiesAggregatorService.contractId, this.ctx);
   }
@@ -34,7 +32,7 @@ export class PropertiesAggregatorService<T extends ChainId> extends ContractServ
   async getProperty(target: Address, paramType: ParamType): Promise<DecodingType> {
     const contract = await this.contract;
     const data = await contract.read.getProperty(target, paramType.name);
-    const decoded = this.coder.decode([paramType.type], data)[0];
+    const decoded = defaultAbiCoder.decode([paramType.type], data)[0];
 
     return Promise.resolve(decoded);
   }
@@ -53,7 +51,7 @@ export class PropertiesAggregatorService<T extends ChainId> extends ContractServ
     const result: Record<string, DecodingType> = {};
     paramTypes.forEach((paramType, index) => {
       const datum = data[index];
-      const decoded = this.coder.decode([paramType.type], datum)[0];
+      const decoded = defaultAbiCoder.decode([paramType.type], datum)[0];
       result[paramType.name] = decoded;
     });
     return Promise.resolve(result);

--- a/src/services/propertiesAggregator.ts
+++ b/src/services/propertiesAggregator.ts
@@ -1,0 +1,49 @@
+import { AbiCoder, ParamType } from "@ethersproject/abi";
+import { BigNumber } from "@ethersproject/bignumber";
+
+import { ChainId } from "../chain";
+import { ContractAddressId, ContractService, WrappedContract } from "../common";
+import { Address } from "../types";
+
+type DecodingType = string | BigNumber;
+
+type PropertyAggregatorArgs = {
+  target: Address;
+  paramType: ParamType;
+};
+
+export class PropertiesAggregatorService<T extends ChainId> extends ContractService<T> {
+  static abi = [
+    "function getProperty(address target, string calldata name) public view returns (bytes memory)",
+    "function getProperties(address target, string[] calldata names) public view returns (bytes[] memory)",
+  ];
+  static contractId = ContractAddressId.propertiesAggregator;
+
+  private coder = new AbiCoder();
+
+  get contract(): Promise<WrappedContract> {
+    return this._getContract(PropertiesAggregatorService.abi, PropertiesAggregatorService.contractId, this.ctx);
+  }
+
+  async getProperty({ target, paramType }: PropertyAggregatorArgs): Promise<string> {
+    const contract = await this.contract;
+    const data = await contract.read.getProperty(target, paramType.name);
+    const decoded = this.coder.decode([paramType.type], data)[0];
+
+    return Promise.resolve(decoded);
+  }
+
+  async getProperties(target: Address, paramTypes: ParamType[]): Promise<Record<string, DecodingType>> {
+    const contract = await this.contract;
+    const names = paramTypes.map((param) => param.name);
+    const data = await contract.read.getProperties(target, names);
+
+    const result: Record<string, DecodingType> = {};
+    paramTypes.forEach((paramType, index) => {
+      const datum = data[index];
+      const decoded = this.coder.decode([paramType.type], datum)[0];
+      result[paramType.name] = decoded;
+    });
+    return Promise.resolve(result);
+  }
+}

--- a/src/yearn.ts
+++ b/src/yearn.ts
@@ -18,6 +18,7 @@ import { MetaService } from "./services/meta";
 import { OracleService } from "./services/oracle";
 import { PartnerService } from "./services/partner";
 import { PickleService } from "./services/partners/pickle";
+import { PropertiesAggregatorService } from "./services/propertiesAggregator";
 import { SubgraphService } from "./services/subgraph";
 import { TelegramService } from "./services/telegram";
 import { TransactionService } from "./services/transaction";
@@ -47,6 +48,7 @@ type ServicesType<T extends ChainId> = {
   pickle: PickleService;
   helper: HelperService<T>;
   partner?: PartnerService<T>;
+  propertiesAggregator: PropertiesAggregatorService<T>;
 };
 
 /**
@@ -163,6 +165,7 @@ export class Yearn<T extends ChainId> {
       allowList: allowlistService,
       transaction: new TransactionService(chainId, ctx, allowlistService),
       partner: ctx.partnerId ? new PartnerService(chainId, ctx, addressProvider, ctx.partnerId) : undefined,
+      propertiesAggregator: new PropertiesAggregatorService(chainId, ctx, addressProvider),
     };
   }
 


### PR DESCRIPTION
## Description
Add a new `PropertiesAggregatorService` which can aggregate multiple property queries on a contract into a single call, with the limitation that there can be no arguments in the properties. This can be used, for example, for fetching multiple properties of a vault at once, while being flexible for adding/removing the properties queried in the future.

Corresponding PR of where the smart contract functionality has been added to lens - https://github.com/yearn/yearn-lens/pull/55

## Motivation and Context
Adding more functionality to the SDK for rendering data about vaults/strategies. This will be followed by adding a function to the vaults interface that supports fetching information about a vault in one call, e.g. name, fees, totalAssets etc

## How Has This Been Tested?
Added unit tests
