### PR TITLE
feat: use yDaemon as meta provider

### DIFF
--- a/src/services/meta.spec.ts
+++ b/src/services/meta.spec.ts
@@ -3,6 +3,8 @@ import { Context } from "../context";
 import { createMockTokenMetadata, createMockVaultMetadata } from "../test-utils/factories";
 import { MetaService } from "./meta";
 
+const META_URL = "https://ydaemon.yearn.finance/api";
+
 describe("MetaService", () => {
   let meta: MetaService;
 
@@ -29,7 +31,7 @@ describe("MetaService", () => {
     it("should fetch all tokens metadata when no addresses are given", async () => {
       await meta.tokens();
 
-      expect(global.fetch).toHaveBeenCalledWith("https://meta.yearn.network/tokens/1/all");
+      expect(global.fetch).toHaveBeenCalledWith(`${META_URL}/tokens/1/all`);
     });
 
     it("should fetch all tokens metadata from the addresses given", async () => {
@@ -44,7 +46,7 @@ describe("MetaService", () => {
       const actual = await meta.tokens(["0x001", "0x003"]);
 
       expect(global.fetch).toHaveBeenCalledTimes(1);
-      expect(global.fetch).toHaveBeenCalledWith("https://meta.yearn.network/tokens/1/all");
+      expect(global.fetch).toHaveBeenCalledWith(`${META_URL}/tokens/1/all`);
       expect(actual).toEqual(expect.arrayContaining([tokenMetadata1, tokenMetadata2]));
       expect(actual).not.toEqual(
         expect.arrayContaining([
@@ -75,7 +77,7 @@ describe("MetaService", () => {
       const actual = await meta.tokens(["0x001", "0x003"]);
 
       expect(global.fetch).toHaveBeenCalledTimes(1);
-      expect(global.fetch).toHaveBeenCalledWith("https://meta.yearn.network/tokens/1/all");
+      expect(global.fetch).toHaveBeenCalledWith(`${META_URL}/tokens/1/all`);
       expect(actual).toEqual(
         expect.arrayContaining([
           {
@@ -102,7 +104,7 @@ describe("MetaService", () => {
     it("should fetch a single token metadata from the address given", async () => {
       await meta.token("0x00");
 
-      expect(global.fetch).toHaveBeenCalledWith("https://meta.yearn.network/tokens/1/0x00");
+      expect(global.fetch).toHaveBeenCalledWith(`${META_URL}/tokens/1/0x00`);
     });
 
     it("should throw when it fails to fetch a single token metadata from the address given", async () => {
@@ -113,7 +115,7 @@ describe("MetaService", () => {
 
       const actual = await meta.token("0x00");
 
-      expect(global.fetch).toHaveBeenCalledWith("https://meta.yearn.network/tokens/1/0x00");
+      expect(global.fetch).toHaveBeenCalledWith(`${META_URL}/tokens/1/0x00`);
       expect(actual).toBe(null);
       expect(console.error).toHaveBeenCalledWith(
         new Error(`Failed to fetch token with address "0x00". HTTP error: 404`)
@@ -125,7 +127,7 @@ describe("MetaService", () => {
     it("should fetch the strategies metadata", async () => {
       await meta.token("0x00");
 
-      expect(global.fetch).toHaveBeenCalledWith("https://meta.yearn.network/tokens/1/0x00");
+      expect(global.fetch).toHaveBeenCalledWith(`${META_URL}/tokens/1/0x00`);
     });
   });
 
@@ -133,7 +135,7 @@ describe("MetaService", () => {
     it("should fetch all vaults metadata when no addresses are given", async () => {
       await meta.vaults();
 
-      expect(global.fetch).toHaveBeenCalledWith("https://meta.yearn.network/vaults/1/all");
+      expect(global.fetch).toHaveBeenCalledWith(`${META_URL}/vaults/1/all`);
     });
 
     it("should fetch all vaults metadata from the addresses given", async () => {
@@ -148,7 +150,7 @@ describe("MetaService", () => {
       const actual = await meta.vaults(["0x001", "0x002"]);
 
       expect(global.fetch).toHaveBeenCalledTimes(1);
-      expect(global.fetch).toHaveBeenCalledWith("https://meta.yearn.network/vaults/1/all");
+      expect(global.fetch).toHaveBeenCalledWith(`${META_URL}/vaults/1/all`);
       expect(actual).toEqual(expect.arrayContaining([vaultMetadata1, vaultMetadata2]));
       expect(actual).not.toEqual(
         expect.arrayContaining([
@@ -164,7 +166,7 @@ describe("MetaService", () => {
     it("should fetch a single vault metadata from the address given", async () => {
       await meta.vault("0x00");
 
-      expect(global.fetch).toHaveBeenCalledWith("https://meta.yearn.network/vaults/1/0x00");
+      expect(global.fetch).toHaveBeenCalledWith(`${META_URL}/vaults/1/0x00`);
     });
 
     it("should throw when it fails to fetch a single vault metadata from the address given", async () => {
@@ -175,7 +177,7 @@ describe("MetaService", () => {
 
       const actual = await meta.vault("0x00");
 
-      expect(global.fetch).toHaveBeenCalledWith("https://meta.yearn.network/vaults/1/0x00");
+      expect(global.fetch).toHaveBeenCalledWith(`${META_URL}/vaults/1/0x00`);
       expect(actual).toBe(null);
       expect(console.error).toHaveBeenCalledWith(
         new Error(`Failed to fetch token with address "0x00". HTTP error: 404`)

--- a/src/services/meta.spec.ts
+++ b/src/services/meta.spec.ts
@@ -31,7 +31,7 @@ describe("MetaService", () => {
     it("should fetch all tokens metadata when no addresses are given", async () => {
       await meta.tokens();
 
-      expect(global.fetch).toHaveBeenCalledWith(`${META_URL}/tokens/1/all`);
+      expect(global.fetch).toHaveBeenCalledWith(`${META_URL}/1/tokens/all`);
     });
 
     it("should fetch all tokens metadata from the addresses given", async () => {
@@ -46,7 +46,7 @@ describe("MetaService", () => {
       const actual = await meta.tokens(["0x001", "0x003"]);
 
       expect(global.fetch).toHaveBeenCalledTimes(1);
-      expect(global.fetch).toHaveBeenCalledWith(`${META_URL}/tokens/1/all`);
+      expect(global.fetch).toHaveBeenCalledWith(`${META_URL}/1/tokens/all`);
       expect(actual).toEqual(expect.arrayContaining([tokenMetadata1, tokenMetadata2]));
       expect(actual).not.toEqual(
         expect.arrayContaining([
@@ -77,7 +77,7 @@ describe("MetaService", () => {
       const actual = await meta.tokens(["0x001", "0x003"]);
 
       expect(global.fetch).toHaveBeenCalledTimes(1);
-      expect(global.fetch).toHaveBeenCalledWith(`${META_URL}/tokens/1/all`);
+      expect(global.fetch).toHaveBeenCalledWith(`${META_URL}/1/tokens/all`);
       expect(actual).toEqual(
         expect.arrayContaining([
           {
@@ -104,7 +104,7 @@ describe("MetaService", () => {
     it("should fetch a single token metadata from the address given", async () => {
       await meta.token("0x00");
 
-      expect(global.fetch).toHaveBeenCalledWith(`${META_URL}/tokens/1/0x00`);
+      expect(global.fetch).toHaveBeenCalledWith(`${META_URL}/1/tokens/0x00`);
     });
 
     it("should throw when it fails to fetch a single token metadata from the address given", async () => {
@@ -115,7 +115,7 @@ describe("MetaService", () => {
 
       const actual = await meta.token("0x00");
 
-      expect(global.fetch).toHaveBeenCalledWith(`${META_URL}/tokens/1/0x00`);
+      expect(global.fetch).toHaveBeenCalledWith(`${META_URL}/1/tokens/0x00`);
       expect(actual).toBe(null);
       expect(console.error).toHaveBeenCalledWith(
         new Error(`Failed to fetch token with address "0x00". HTTP error: 404`)
@@ -127,7 +127,7 @@ describe("MetaService", () => {
     it("should fetch the strategies metadata", async () => {
       await meta.token("0x00");
 
-      expect(global.fetch).toHaveBeenCalledWith(`${META_URL}/tokens/1/0x00`);
+      expect(global.fetch).toHaveBeenCalledWith(`${META_URL}/1/tokens/0x00`);
     });
   });
 
@@ -135,7 +135,7 @@ describe("MetaService", () => {
     it("should fetch all vaults metadata when no addresses are given", async () => {
       await meta.vaults();
 
-      expect(global.fetch).toHaveBeenCalledWith(`${META_URL}/vaults/1/all`);
+      expect(global.fetch).toHaveBeenCalledWith(`${META_URL}/1/vaults/all`);
     });
 
     it("should fetch all vaults metadata from the addresses given", async () => {
@@ -150,7 +150,7 @@ describe("MetaService", () => {
       const actual = await meta.vaults(["0x001", "0x002"]);
 
       expect(global.fetch).toHaveBeenCalledTimes(1);
-      expect(global.fetch).toHaveBeenCalledWith(`${META_URL}/vaults/1/all`);
+      expect(global.fetch).toHaveBeenCalledWith(`${META_URL}/1/vaults/all`);
       expect(actual).toEqual(expect.arrayContaining([vaultMetadata1, vaultMetadata2]));
       expect(actual).not.toEqual(
         expect.arrayContaining([
@@ -166,7 +166,7 @@ describe("MetaService", () => {
     it("should fetch a single vault metadata from the address given", async () => {
       await meta.vault("0x00");
 
-      expect(global.fetch).toHaveBeenCalledWith(`${META_URL}/vaults/1/0x00`);
+      expect(global.fetch).toHaveBeenCalledWith(`${META_URL}/1/vaults/0x00`);
     });
 
     it("should throw when it fails to fetch a single vault metadata from the address given", async () => {
@@ -177,7 +177,7 @@ describe("MetaService", () => {
 
       const actual = await meta.vault("0x00");
 
-      expect(global.fetch).toHaveBeenCalledWith(`${META_URL}/vaults/1/0x00`);
+      expect(global.fetch).toHaveBeenCalledWith(`${META_URL}/1/vaults/0x00`);
       expect(actual).toBe(null);
       expect(console.error).toHaveBeenCalledWith(
         new Error(`Failed to fetch token with address "0x00". HTTP error: 404`)

--- a/src/services/meta.ts
+++ b/src/services/meta.ts
@@ -10,7 +10,7 @@ const META_URL = "https://ydaemon.yearn.finance/api";
  */
 export class MetaService extends Service {
   async tokens(addresses?: Address[]): Promise<TokenMetadata[]> {
-    const tokensMetadata: TokenMetadata[] = await fetch(`${META_URL}/tokens/${this.chainId}/all`).then((res) =>
+    const tokensMetadata: TokenMetadata[] = await fetch(`${META_URL}/${this.chainId}/tokens/all`).then((res) =>
       res.json()
     );
 
@@ -41,7 +41,7 @@ export class MetaService extends Service {
 
   async token(address: Address): Promise<TokenMetadata | null> {
     try {
-      const response = await fetch(`${META_URL}/tokens/${this.chainId}/${address}`);
+      const response = await fetch(`${META_URL}/${this.chainId}/tokens/${address}`);
 
       if (!response.ok) {
         throw new SdkError(`Failed to fetch token with address "${address}". HTTP error: ${response.status}`);
@@ -65,11 +65,11 @@ export class MetaService extends Service {
   }
 
   async strategies(): Promise<StrategiesMetadata[]> {
-    return fetch(`${META_URL}/strategies/${this.chainId}/all`).then((res) => res.json());
+    return fetch(`${META_URL}/${this.chainId}/strategies/all`).then((res) => res.json());
   }
 
   async vaults(addresses?: Address[]): Promise<VaultMetadataOverrides[]> {
-    const vaultsMetadata = await fetch(`${META_URL}/vaults/${this.chainId}/all`).then((res) => res.json());
+    const vaultsMetadata = await fetch(`${META_URL}/${this.chainId}/vaults/all`).then((res) => res.json());
 
     if (!addresses) {
       return vaultsMetadata;
@@ -80,7 +80,7 @@ export class MetaService extends Service {
 
   async vault(address: Address): Promise<VaultMetadataOverrides | null> {
     try {
-      const response = await fetch(`${META_URL}/vaults/${this.chainId}/${address}`);
+      const response = await fetch(`${META_URL}/${this.chainId}/vaults/${address}`);
 
       if (!response.ok) {
         throw new SdkError(`Failed to fetch token with address "${address}". HTTP error: ${response.status}`);

--- a/src/services/meta.ts
+++ b/src/services/meta.ts
@@ -2,7 +2,7 @@ import { Service } from "../common";
 import { Address, SdkError, StrategiesMetadata, TokenMetadata, VaultMetadataOverrides } from "../types";
 import { getLocalizedString } from "../utils/localization";
 
-const META_URL = "https://meta.yearn.network";
+const META_URL = "https://ydaemon.yearn.finance/api";
 
 /**
  * [[MetaService]] fetches meta data about things such as vaults and tokens


### PR DESCRIPTION
## Description

Update thee Yearn Meta endpoint to use yDaemon new system

## Related Issue

*N/A*

## Motivation and Context

Yearn Meta has been merged with yDaemon. The endpoint has not been updated (yet) and, in order to keep it up-to-date, we should update it

## How Has This Been Tested?

Endpoint is working, further E2E testing could be useful, but I miss the setup here :|

## Screenshots (if appropriate):
